### PR TITLE
Add test_notification

### DIFF
--- a/apps/core/views/viewsets/notification.py
+++ b/apps/core/views/viewsets/notification.py
@@ -35,7 +35,7 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet, ActionAPIViewSet):
     def read_all(self, request, *args, **kwargs):
         notification_read_logs = NotificationReadLog.objects.filter(
             read_by=request.user,
-            id__in=[notification.id for notification in self.get_queryset()]
+            notification__in=[notification.id for notification in self.get_queryset()]
         )
 
         notification_read_logs.update(is_read=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def set_user_client(request):
     request.cls.api_client = client
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='class')
 def set_user_client2(request):
     request.cls.user2, _ = User.objects.get_or_create(username='User2', email='user2@sparcs.org')
     client = APIClient()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def set_user_client(request):
     request.cls.api_client = client
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='function')
 def set_user_client2(request):
     request.cls.user2, _ = User.objects.get_or_create(username='User2', email='user2@sparcs.org')
     client = APIClient()

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -33,33 +33,25 @@ def set_comments(request):
     """set_articles 먼저 적용"""
     request.cls.comment = Comment.objects.create(
         content='댓글입니다.',
-        created_by=request.cls.user,
+        created_by=request.cls.user2,
         parent_article=request.cls.article
     )
 
+    request.cls.comment_reply = Comment.objects.create(
+        content='대댓글입니다.',
+        created_by=request.cls.user,
+        parent_comment=request.cls.comment
+    )
 
-@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_articles', 'set_comments')
+
+@pytest.mark.usefixtures('set_user_clients', 'set_board', 'set_articles', 'set_comments')
 class TestNotification(TestCase, RequestSetting):
     def test_list(self):
-        Notification.objects.create(
-            type='article_commented',
-            title='테스트1',
-            content='내용1',
-            related_article=self.article,
-            related_comment=None
-        )
-
-        Notification.objects.create(
-            type='comment_commented',
-            title='테스트2',
-            content='내용2',
-            related_comment=self.comment,
-            related_article=None
-        )
-
         notifications = self.http_request('get', 'notifications')
 
         assert notifications.status_code == 200
+        # user에게 알림: user의 글에 user2가 댓글을 달아서
+        # user2에게 알림: user2의 댓글에 user가 대댓글을 달아서
         assert Notification.objects.all().count() == 2
 
         # not working

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -20,16 +20,16 @@ def set_board(request):
 def set_articles(request):
     """set_board 먼저 적용"""
     request.cls.article = Article.objects.create(
-        title='테스트1 글입니다.',
-        content='테스트1 내용입니다.',
-        content_text='테스트1 텍스트',
+        title='테스트 글입니다.',
+        content='테스트 내용입니다.',
+        content_text='테스트 텍스트',
         parent_board=request.cls.board,
         created_by=request.cls.user
     )
 
 
 @pytest.fixture(scope='class')
-def set_comments(request):
+def set_comment(request):
     """set_articles 먼저 적용"""
     request.cls.comment = Comment.objects.create(
         content='댓글입니다.',
@@ -37,48 +37,56 @@ def set_comments(request):
         parent_article=request.cls.article
     )
 
-    request.cls.comment_reply = Comment.objects.create(
-        content='대댓글입니다.',
-        created_by=request.cls.user,
-        parent_comment=request.cls.comment
-    )
 
-
-@pytest.mark.usefixtures('set_user_clients', 'set_board', 'set_articles', 'set_comments')
+@pytest.mark.usefixtures('set_user_clients', 'set_board', 'set_articles', 'set_comment')
 class TestNotification(TestCase, RequestSetting):
-    def test_list(self):
+    def test_notification_article_commented(self):
+        self.api_client.force_authenticate(user=self.user)
         notifications = self.http_request('get', 'notifications')
 
-        assert notifications.status_code == 200
         # user에게 알림: user의 글에 user2가 댓글을 달아서
-        # user2에게 알림: user2의 댓글에 user가 대댓글을 달아서
-        assert Notification.objects.all().count() == 2
+        assert notifications.status_code == 200
+        assert Notification.objects.all().count() == 1
 
-        # not working
-        # assert notifications.data.get('num_items') == 2
+        assert notifications.data.get('num_items') == 1
 
-
-@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_articles', 'set_comments')
-class TestNotificationReadLog(TestCase, RequestSetting):
-    def test_read(self):
-        notification = Notification.objects.create(
-            type='article_commented',
-            title='테스트1',
-            content='내용1',
-            related_article=self.article
+    def test_notification_comment_commented(self):
+        Comment.objects.create(
+            content='대댓글입니다.',
+            created_by=self.user,
+            parent_comment=self.comment
         )
 
+        self.api_client.force_authenticate(user=self.user2)
+        notifications = self.http_request('get', 'notifications')
+
+        # user2에게 알림: user2의 댓글에 user가 대댓글을 달아서
+        assert notifications.status_code == 200
+        assert Notification.objects.all().count() == 2
+
+        assert notifications.data.get('num_items') == 1
+
+'''
+@pytest.mark.usefixtures('set_user_clients', 'set_board', 'set_articles', 'set_comments')
+class TestNotificationReadLog(TestCase, RequestSetting):
+    def test_read(self):
+        notification = Notification.objects.first()
+
+        print(notification.__dict__)
         noti_dict = {'user': self.user.id}
 
         notification_read = self.http_request('post', f'notifications/{notification.id}/read', noti_dict)
 
-        # gets error
         assert notification_read.status_code == 200
 
         # gets error
         # check is_read == true
-        notification_read_log = NotificationReadLog.objects.filter(read_by=self.user, notification=notification).first()
+        notification_read_log = NotificationReadLog.objects.filter(read_by=self.user, notification=notification).all()
+
+        print (notification_read_log.__dict__)
+
         assert notification_read_log.is_read
+
 
     def test_read_all(self):
         Notification.objects.create(
@@ -106,24 +114,4 @@ class TestNotificationReadLog(TestCase, RequestSetting):
             print(noti)
             notification_read_log = NotificationReadLog.objects.filter(read_by=self.user, notification=noti).first()
             assert notification_read_log.is_read
-
-'''
-    # on progress
-    
-    def test_notification_when_commented_on_article(self):
-        new_comment = Comment.objects.create(
-            content='댓글2입니다.',
-            created_by=self.user,
-            parent_article=self.article
-        )
-        Notification.notify_commented(new_comment)
-
-    def test_notification_when_commented_on_comment(self):
-        new_comment = Comment.objects.create(
-            content='댓글2입니다.',
-            created_by=self.user,
-            parent_article=self.comment
-        )
-        Notification.notify_commented(new_comment)
-    
 '''

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,137 @@
+import pytest
+from django.test import TestCase
+from tests.conftest import RequestSetting
+
+from apps.core.models import Notification, NotificationReadLog, Article, Board, Comment
+
+
+@pytest.fixture(scope='class')
+def set_board(request):
+    request.cls.board = Board.objects.create(
+        slug='free',
+        ko_name='자유 게시판',
+        en_name='Free Board',
+        ko_description='자유 게시판 입니다.',
+        en_description='This is a free board.'
+    )
+
+
+@pytest.fixture(scope='class')
+def set_articles(request):
+    """set_board 먼저 적용"""
+    request.cls.article = Article.objects.create(
+        title='테스트1 글입니다.',
+        content='테스트1 내용입니다.',
+        content_text='테스트1 텍스트',
+        parent_board=request.cls.board,
+        created_by=request.cls.user
+    )
+
+
+@pytest.fixture(scope='class')
+def set_comments(request):
+    """set_articles 먼저 적용"""
+    request.cls.comment = Comment.objects.create(
+        content='댓글입니다.',
+        created_by=request.cls.user,
+        parent_article=request.cls.article
+    )
+
+
+@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_articles', 'set_comments')
+class TestNotification(TestCase, RequestSetting):
+    def test_list(self):
+        Notification.objects.create(
+            type='article_commented',
+            title='테스트1',
+            content='내용1',
+            related_article=self.article,
+            related_comment=None
+        )
+
+        Notification.objects.create(
+            type='comment_commented',
+            title='테스트2',
+            content='내용2',
+            related_comment=self.comment,
+            related_article=None
+        )
+
+        notifications = self.http_request('get', 'notifications')
+
+        assert notifications.status_code == 200
+        assert Notification.objects.all().count() == 2
+
+        # not working
+        # assert notifications.data.get('num_items') == 2
+
+
+@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_articles', 'set_comments')
+class TestNotificationReadLog(TestCase, RequestSetting):
+    def test_read(self):
+        notification = Notification.objects.create(
+            type='article_commented',
+            title='테스트1',
+            content='내용1',
+            related_article=self.article
+        )
+
+        noti_dict = {'user': self.user.id}
+
+        notification_read = self.http_request('post', f'notifications/{notification.id}/read', noti_dict)
+
+        # gets error
+        assert notification_read.status_code == 200
+
+        # gets error
+        # check is_read == true
+        notification_read_log = NotificationReadLog.objects.filter(read_by=self.user, notification=notification).first()
+        assert notification_read_log.is_read
+
+    def test_read_all(self):
+        Notification.objects.create(
+            type='article_commented',
+            title='테스트1',
+            content='내용1',
+            related_article=self.article
+        )
+
+        Notification.objects.create(
+            type='comment_commented',
+            title='테스트2',
+            content='내용2',
+            related_comment=self.comment
+        )
+
+        noti_dict = {'user': self.user.id}
+
+        notification_read = self.http_request('post', 'notifications/read_all', noti_dict)
+        assert notification_read.status_code == 200
+
+        # gets error
+        # check is_read == true
+        for noti in notification_read:
+            print(noti)
+            notification_read_log = NotificationReadLog.objects.filter(read_by=self.user, notification=noti).first()
+            assert notification_read_log.is_read
+
+'''
+    # on progress
+    
+    def test_notification_when_commented_on_article(self):
+        new_comment = Comment.objects.create(
+            content='댓글2입니다.',
+            created_by=self.user,
+            parent_article=self.article
+        )
+        Notification.notify_commented(new_comment)
+
+    def test_notification_when_commented_on_comment(self):
+        new_comment = Comment.objects.create(
+            content='댓글2입니다.',
+            created_by=self.user,
+            parent_article=self.comment
+        )
+        Notification.notify_commented(new_comment)
+    
+'''


### PR DESCRIPTION
notification에 대한 test code 작성

테스트 내용
1. 게시글에 댓글이 달렸을 때, 댓글에 대댓글이 달렸을 때 notification이 잘 생성 되었는지 테스트
2. notification를 성공적으로 읽을 수 있는지 테스트 (notification들 중 하나만 읽을 때). read 함수 테스트
3. notification를 성공적으로 읽을 수 있는지 테스트 (notification 모두 읽을 때). read_all 함수 테스트
4. (미완) notify_commented 함수 테스트

안 되는 것
1. request status는 200 반환되나 num_item가 0이 나와 맞지 않는 상태 (object 생성은 잘 되지만 queryset에 추가가 안 되는 것 같음)
2. post로 http request 보내면 404가 뜸. viewset에서 queryset 구성이 잘 안 되는 것을 확인함.
3. 2번과 마찬가지