### PR TITLE
Add checks to block self-voting

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -170,7 +170,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         article = self.get_object()
 
         if article.created_by_id == request.user.id:
-            return response.Response(status=status.HTTP_403_FORBIDDEN)
+            return response.Response({'message': '본인 글에는 좋아요를 누를 수 없습니다.'}, status=status.HTTP_403_FORBIDDEN)
 
         Vote.objects.update_or_create(
             voted_by=request.user,
@@ -189,7 +189,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         article = self.get_object()
 
         if article.created_by_id == request.user.id:
-            return response.Response(status=status.HTTP_403_FORBIDDEN)
+            return response.Response({'message': '본인 글에는 싫어요를 누를 수 없습니다.'}, status=status.HTTP_403_FORBIDDEN)
 
         Vote.objects.update_or_create(
             voted_by=request.user,

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -169,6 +169,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def vote_positive(self, request, *args, **kwargs):
         article = self.get_object()
 
+        if article.created_by_id == request.user.id:
+            return response.Response(status=status.HTTP_403_FORBIDDEN)
+
         Vote.objects.update_or_create(
             voted_by=request.user,
             parent_article=article,
@@ -184,6 +187,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     @decorators.action(detail=True, methods=['post'])
     def vote_negative(self, request, *args, **kwargs):
         article = self.get_object()
+
+        if article.created_by_id == request.user.id:
+            return response.Response(status=status.HTTP_403_FORBIDDEN)
 
         Vote.objects.update_or_create(
             voted_by=request.user,

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -229,12 +229,14 @@ class TestArticle(TestCase, RequestSetting):
         # 자신이 쓴 게시물은 좋아요 / 싫어요를 할 수 없음
         resp = self.http_request(self.user, 'post', f'articles/{self.article.id}/vote_positive')
         assert resp.status_code == 403
+        assert resp.data["message"] is not None
         article = Article.objects.get(id=self.article.id)
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 0
 
         resp = self.http_request(self.user, 'post', f'articles/{self.article.id}/vote_negative')
         assert resp.status_code == 403
+        assert resp.data["message"] is not None
         article = Article.objects.get(id=self.article.id)
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 0

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -225,3 +225,16 @@ class TestArticle(TestCase, RequestSetting):
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 1
 
+    def test_self_vote(self):
+        # 자신이 쓴 게시물은 좋아요 / 싫어요를 할 수 없음
+        resp = self.http_request(self.user, 'post', f'articles/{self.article.id}/vote_positive')
+        assert resp.status_code == 403
+        article = Article.objects.get(id=self.article.id)
+        assert article.positive_vote_count == 0
+        assert article.negative_vote_count == 0
+
+        resp = self.http_request(self.user, 'post', f'articles/{self.article.id}/vote_negative')
+        assert resp.status_code == 403
+        article = Article.objects.get(id=self.article.id)
+        assert article.positive_vote_count == 0
+        assert article.negative_vote_count == 0

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -52,9 +52,8 @@ def set_article(request):
 
 @pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_board', 'set_topic', 'set_article')
 class TestArticle(TestCase, RequestSetting):
-
-    # article 개수를 확인하는 테스트
     def test_list(self):
+        # article 개수를 확인하는 테스트
         res = self.http_request(self.user, 'get', 'articles')
         assert res.data.get('num_items') == 1
 
@@ -93,11 +92,9 @@ class TestArticle(TestCase, RequestSetting):
         res = self.http_request(self.user, 'get', 'articles')
         assert res.data.get('num_items') == 3
 
-
-    # article retrieve가 잘 되는지 확인
     def test_get(self):
+        # article 조회가 잘 되는지 확인
         res = self.http_request(self.user, 'get', f'articles/{self.article.id}').data
-
         assert res.get('title') == self.article.title
         assert res.get('content') == self.article.content
         assert res.get('content_text') == self.article.content_text
@@ -110,10 +107,8 @@ class TestArticle(TestCase, RequestSetting):
         assert res.get('parent_topic')['ko_name'] == self.article.parent_topic.ko_name
         assert res.get('parent_board')['ko_name'] == self.article.parent_board.ko_name
 
-
-    # 익명의 글쓴이가 익명임을 확인
     def test_anonymous_writer(self):
-
+        # 익명의 글쓴이가 익명임을 확인
         article = Article.objects.create(
             title="example article",
             content="example content",
@@ -132,9 +127,8 @@ class TestArticle(TestCase, RequestSetting):
 
         assert self.http_request(self.user, 'get', f'articles/{article.id}').data.get('created_by') == '익명'
 
-
-    # test_create: HTTP request (POST)를 이용해서 생성
     def test_create(self):
+        # test_create: HTTP request (POST)를 이용해서 생성
         # user data in dict
         user_data = {
             "title": "article for test_create",
@@ -150,30 +144,26 @@ class TestArticle(TestCase, RequestSetting):
         self.http_request(self.user, 'post', 'articles', user_data)
         assert Article.objects.filter(title='article for test_create')
 
-
-    def test_update_hitcounts(self):
-        previous_hitcount = self.article.hit_count
+    def test_update_hit_counts(self):
+        previous_hit_count = self.article.hit_count
         res = self.http_request(self.user2, 'get', f'articles/{self.article.id}').data
-        assert res.get('hit_count') == previous_hitcount + 1
-        assert Article.objects.get(id=self.article.id).hit_count == previous_hitcount + 1
+        assert res.get('hit_count') == previous_hit_count + 1
+        assert Article.objects.get(id=self.article.id).hit_count == previous_hit_count + 1
 
-
-    # 글쓴이가 아닌 사람은 글을 지울 수 없음
-    def test_delete_by_nonwriter(self):
+    def test_delete_by_non_writer(self):
+        # 글쓴이가 아닌 사람은 글을 지울 수 없음
         assert Article.objects.filter(id=self.article.id)
         self.http_request(self.user2, 'delete', f'articles/{self.article.id}')
         assert Article.objects.filter(id=self.article.id)
 
-
-    # 글쓴이는 본인 글을 지울 수 있음
     def test_delete_by_writer(self):
+        # 글쓴이는 본인 글을 지울 수 있음
         assert Article.objects.filter(id=self.article.id)
         self.http_request(self.user, 'delete', f'articles/{self.article.id}')
         assert not Article.objects.filter(id=self.article.id)
 
-
-    # user가 만든 set_article의 positive vote, negative vote 를 set_user_client2를 이용해서 바꿈 (투표 취소 가능한지, 둘다 중복투표 불가능한지 확인)
     def test_update_votes(self):
+        # user가 만든 set_article의 positive vote, negative vote 를 set_user_client2를 이용해서 바꿈 (투표 취소 가능한지, 둘다 중복투표 불가능한지 확인)
         # positive vote 확인
         self.http_request(self.user2, 'post', f'articles/{self.article.id}/vote_positive')
         article = Article.objects.get(id=self.article.id)
@@ -234,3 +224,4 @@ class TestArticle(TestCase, RequestSetting):
         article = Article.objects.get(id=self.article.id)
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 1
+


### PR DESCRIPTION
## 개요
자신이 작성한 게시물에는 좋아요, 싫어요를 할 수 없게 합니다. 요청을 보낼 경우 403을 반환합니다.

## 세부 수정사항
- 관련 테스트 추가 (`test_self_vote`)
- 투표 view에 게시물 작성자, 사용자 pk 비교 추가