### PR TITLE
Add search filter for articles

### DIFF
--- a/apps/core/filters/article.py
+++ b/apps/core/filters/article.py
@@ -60,6 +60,12 @@ class ArticleFilter(filters.FilterSet):
         method='get_title_or_content_text__contains',
     )
 
+    main_search = filters.CharFilter(
+        name='main_search',
+        label='메인 검색 (제목포함, 본문포함, 닉네임일치)',
+        method='get_main_search'
+    )
+
     @staticmethod
     def get_title_or_content__contains(queryset, name, value):
         return queryset.filter(
@@ -72,4 +78,12 @@ class ArticleFilter(filters.FilterSet):
         return queryset.filter(
             models.Q(title__contains=value) |
             models.Q(content_text__contains=value)
+        ).distinct()
+
+    @staticmethod
+    def get_main_search(queryset, name, value):
+        return queryset.filter(
+            models.Q(title__contains=value) |
+            models.Q(content_text__contains=value) |
+            models.Q(created_by__profile__nickname=value)
         ).distinct()

--- a/apps/core/filters/article.py
+++ b/apps/core/filters/article.py
@@ -60,10 +60,10 @@ class ArticleFilter(filters.FilterSet):
         method='get_title_or_content_text__contains',
     )
 
-    main_search = filters.CharFilter(
+    main_search__contains = filters.CharFilter(
         field_name='main_search',
         label='메인 검색 (제목포함, 본문포함, 닉네임일치)',
-        method='get_main_search'
+        method='get_main_search__contains'
     )
 
     @staticmethod
@@ -81,9 +81,9 @@ class ArticleFilter(filters.FilterSet):
         ).distinct()
 
     @staticmethod
-    def get_main_search(queryset, name, value):
+    def get_main_search__contains(queryset, name, value):
         return queryset.filter(
             models.Q(title__contains=value) |
             models.Q(content_text__contains=value) |
-            models.Q(created_by__profile__nickname=value)
+            models.Q(created_by__profile__nickname__contains=value)
         ).distinct()

--- a/apps/core/filters/article.py
+++ b/apps/core/filters/article.py
@@ -49,19 +49,19 @@ class ArticleFilter(filters.FilterSet):
         }
 
     title_or_content__contains = filters.CharFilter(
-        name='title_or_content__contains',
+        field_name='title_or_content__contains',
         label='제목 or 본문 contains',
         method='get_title_or_content__contains',
     )
 
     title_or_content_text__contains = filters.CharFilter(
-        name='title_or_content_text__contains',
+        field_name='title_or_content_text__contains',
         label='제목 or 본문 contains',
         method='get_title_or_content_text__contains',
     )
 
     main_search = filters.CharFilter(
-        name='main_search',
+        field_name='main_search',
         label='메인 검색 (제목포함, 본문포함, 닉네임일치)',
         method='get_main_search'
     )

--- a/tests/test_article_search.py
+++ b/tests/test_article_search.py
@@ -46,7 +46,7 @@ def set_posts(request):
         if i % 7 == 0:
             article_content += 'CCCC'
         new_article = Article.objects.create(
-            title=('게시물 %d' % (i+1)),
+            title=f'게시물 {i+1}',
             content=article_content,
             content_text=article_content,
             is_anonymous=False,
@@ -74,15 +74,13 @@ class TestArticleSearch(TestCase, RequestSetting):
 
     def test_main_search(self):
         # `main_search` 필터를 검사합니다. 개수 assertion 숫자들의 의미는 set_posts를 참고하세요.
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=AAAA')
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search__contains=AAAA')
         assert response.data['num_items'] == 34
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=BBBB')
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search__contains=BBBB')
         assert response.data['num_items'] == 20
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=CCCC')
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search__contains=CCCC')
         assert response.data['num_items'] == 15
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=테스트')
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search__contains=테스트')
         assert response.data['num_items'] == 100
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=2')
-        assert response.data['num_items'] == 19  # *2, 2*: 총 19개
-        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=User2')
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search__contains=User2')
         assert response.data['num_items'] == 25

--- a/tests/test_article_search.py
+++ b/tests/test_article_search.py
@@ -1,0 +1,88 @@
+import pytest
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from apps.core.models import Board, Article
+from apps.user.models import UserProfile
+from tests.conftest import RequestSetting
+
+# TODO: test_articles fixture와 중복되는 코드 합치기
+
+@pytest.fixture(scope='class')
+def set_board(request):
+    request.cls.board = Board.objects.create(
+        slug="test board",
+        ko_name="테스트 게시판",
+        en_name="Test Board",
+        ko_description="테스트 게시판입니다",
+        en_description="This is a board for testing"
+    )
+
+
+@pytest.fixture(scope='class')
+def set_authors(request):
+    # 사용자를 4명 추가합니다.
+    request.cls.authors = []
+    for i in range(4):
+        new_user, _ = User.objects.get_or_create(username=f'User{i+1}', email=f'user{i+1}@sparcs.org')
+        if not hasattr(request.cls.user, 'profile'):
+            UserProfile.objects.get_or_create(user=new_user, nickname=f'User{i+1}')
+        request.cls.authors.append(new_user)
+
+
+@pytest.fixture(scope='class')
+def set_posts(request):
+    """
+    게시물 100개를 추가합니다. 게시물 제목, 작성자, 내용이 번호에 따라 달라집니다.
+    `set_authors`, `set_board` 가 먼저 셋팅되어야 합니다.
+    """
+    request.cls.posts = []
+    for i in range(100):
+        article_content = f'테스트 게시물입니다. '
+        if i % 3 == 0:
+            article_content += 'AAAA'
+        if i % 5 == 0:
+            article_content += 'BBBB'
+        if i % 7 == 0:
+            article_content += 'CCCC'
+        new_article = Article.objects.create(
+            title=('게시물 %d' % (i+1)),
+            content=article_content,
+            content_text=article_content,
+            is_anonymous=False,
+            is_content_sexual=False,
+            is_content_social=False,
+            created_by=request.cls.authors[i % 4],
+            parent_board=request.cls.board
+        )
+        request.cls.posts.append(new_article)
+
+@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_authors', 'set_posts')
+class TestArticleSearch(TestCase, RequestSetting):
+    def test_title_or_content(self):
+        # `title_or_content__contains` 필터를 검사합니다. 개수 assertion 숫자들의 의미는 set_posts를 참고하세요.
+        response = self.http_request(self.user, 'get', 'articles', querystring='title_or_content__contains=AAAA')
+        assert response.data['num_items'] == 34
+        response = self.http_request(self.user, 'get', 'articles', querystring='title_or_content__contains=BBBB')
+        assert response.data['num_items'] == 20
+        response = self.http_request(self.user, 'get', 'articles', querystring='title_or_content__contains=CCCC')
+        assert response.data['num_items'] == 15
+        response = self.http_request(self.user, 'get', 'articles', querystring='title_or_content__contains=2')
+        assert response.data['num_items'] == 19  # *2, 2*: 총 19개
+        response = self.http_request(self.user, 'get', 'articles', querystring='title_or_content__contains=테스트')
+        assert response.data['num_items'] == 100
+
+    def test_main_search(self):
+        # `main_search` 필터를 검사합니다. 개수 assertion 숫자들의 의미는 set_posts를 참고하세요.
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=AAAA')
+        assert response.data['num_items'] == 34
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=BBBB')
+        assert response.data['num_items'] == 20
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=CCCC')
+        assert response.data['num_items'] == 15
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=테스트')
+        assert response.data['num_items'] == 100
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=2')
+        assert response.data['num_items'] == 19  # *2, 2*: 총 19개
+        response = self.http_request(self.user, 'get', 'articles', querystring='main_search=User2')
+        assert response.data['num_items'] == 25


### PR DESCRIPTION
- 제목 포함 or 본문 포함 or 닉네임 일치로 Article 검색 필터 추가
- 기존 `get_title_or_content__contains` 포함해 검색 필터에 대한 테스트 추가
- 쿼리 최적화는 아직 필요