### PR TITLE
Use BestArticleListActionSerializer for optimizing queryset of HomeView

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -375,6 +375,15 @@ class ArticleListActionSerializer(BaseArticleSerializer):
     )
 
 
+class BestArticleListActionSerializer(BaseArticleSerializer):
+    title = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    created_by = serializers.SerializerMethodField(
+        read_only=True,
+    )
+
+
 class ArticleCreateActionSerializer(BaseArticleSerializer):
     class Meta(BaseArticleSerializer.Meta):
         exclude = ()

--- a/apps/core/views/home.py
+++ b/apps/core/views/home.py
@@ -1,7 +1,7 @@
 from rest_framework import views, response
 
 from apps.core.models import BestArticle, PERIOD_CHOICES, BEST_BY_CHOICES
-from apps.core.serializers.article import ArticleListActionSerializer
+from apps.core.serializers.article import BestArticleListActionSerializer
 
 
 class HomeView(views.APIView):
@@ -20,7 +20,7 @@ def _best_articles(period, best_by, request):
         raise ValueError(
             'Wrong period or best_by: {} / {}'.format(period, best_by))
 
-    return ArticleListActionSerializer(
+    return BestArticleListActionSerializer(
         instance=[
             best_article.article for best_article
             in BestArticle.objects.filter(period=period, best_by=best_by).all()[:5]


### PR DESCRIPTION
[SmallBoard component](https://github.com/sparcs-kaist/new-ara-web/blob/dev/src/components/SmallBoard.vue) 에서 사용하는 field는 id, title, created_by 밖에 없습니다.
하지만, ArticleListActionSerializer 에서 요구하고 쿼리하는 필드가 너무 많아서 HomeView가 느려지는 감이 있어 PR을 작성했습니다.

before:
![localhost_8000_api_home_](https://user-images.githubusercontent.com/13573120/93687394-9234f900-faf8-11ea-9fa3-d7d0eb86f51f.png)

after:
![localhost_8000_api_home_ (1)](https://user-images.githubusercontent.com/13573120/93687395-93febc80-faf8-11ea-9715-3c36e7a51ea1.png)
