### PR TITLE
optimize query of ArticleViewSet list action

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -133,9 +133,4 @@ class Article(MetaDataModel):
 
     @property
     def nested_comments_count(self):
-        from apps.core.models import Comment
-
-        return Comment.objects.filter(
-            models.Q(parent_article=self) |
-            models.Q(parent_comment__parent_article=self)
-        ).count()
+        return sum([self.comment_set.count(), self.comment_set__comment_set.count()])

--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -133,4 +133,12 @@ class Article(MetaDataModel):
 
     @property
     def nested_comments_count(self):
-        return sum([self.comment_set.count(), self.comment_set__comment_set.count()])
+        from apps.core.models import Comment
+
+        if hasattr(self, 'comment_set__count') and hasattr(self, 'comment_set__comment_set__count'):
+            return sum([self.comment_set__count, self.comment_set__comment_set__count])
+
+        return Comment.objects.filter(
+            models.Q(parent_article=self) |
+            models.Q(parent_comment__parent_article=self)
+        ).count()

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -65,8 +65,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         if self.action == 'list':
             # optimizing queryset for list action
             # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.select_related(
-            ).prefetch_related(
+            queryset = queryset.prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
@@ -75,13 +74,14 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 'article_update_log_set',
                 Block.prefetch_my_block(self.request.user),
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
+                'comment_set',
+                'comment_set__comment_set',
             )
 
         else:
             # optimizing queryset for create, update, retrieve actions
             # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.select_related(
-            ).prefetch_related(
+            queryset = queryset.prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -59,16 +59,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         ),
     }
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
-
-        if self.action == 'best':
-            queryset = queryset.filter(
-                best__isnull=False,
-            )
-
-        return queryset
-
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -64,12 +64,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         if self.action == 'list':
             # optimizing queryset for list action
-            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.prefetch_related(
+            queryset = queryset.select_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
                 'parent_board',
+            ).prefetch_related(
                 'attachments',
                 'article_update_log_set',
                 Block.prefetch_my_block(self.request.user),
@@ -83,12 +83,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         else:
             # optimizing queryset for create, update, retrieve actions
-            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.prefetch_related(
+            queryset = queryset.select_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
                 'parent_board',
+            ).prefetch_related(
                 'attachments',
                 Scrap.prefetch_my_scrap(self.request.user),
                 Block.prefetch_my_block(self.request.user),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -76,6 +76,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
                 'comment_set',
                 'comment_set__comment_set',
+            ).annotate(
+                comment_set__count=models.Count('comment_set'),
+                comment_set__comment_set__count=models.Count('comment_set__comment_set'),
             )
 
         else:

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -62,7 +62,22 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 
-        if self.action != 'list':
+        if self.action == 'list':
+            # optimizing queryset for list action
+            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
+            queryset = queryset.select_related(
+            ).prefetch_related(
+                'created_by',
+                'created_by__profile',
+                'parent_topic',
+                'parent_board',
+                'attachments',
+                'article_update_log_set',
+                Block.prefetch_my_block(self.request.user),
+                ArticleReadLog.prefetch_my_article_read_log(self.request.user),
+            )
+
+        else:
             # optimizing queryset for create, update, retrieve actions
             # cacheops 이용으로 select_related에서 prefetch_related로 옮김
             queryset = queryset.select_related(
@@ -99,23 +114,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             )
 
         return queryset
-
-    def paginate_queryset(self, queryset):
-        # optimizing queryset for list action
-        # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-        queryset = queryset.select_related(
-        ).prefetch_related(
-            'created_by',
-            'created_by__profile',
-            'parent_topic',
-            'parent_board',
-            'attachments',
-            'article_update_log_set',
-            Block.prefetch_my_block(self.request.user),
-            ArticleReadLog.prefetch_my_article_read_log(self.request.user),
-        )
-
-        return super().paginate_queryset(queryset)
 
     def perform_create(self, serializer):
         serializer.save(

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -21,9 +21,7 @@ class CommentViewSet(mixins.CreateModelMixin,
                      mixins.UpdateModelMixin,
                      mixins.DestroyModelMixin,
                      ActionAPIViewSet):
-    # cacheops 이용으로 select_related에서 prefetch_related로 옮김
     queryset = Comment.objects.select_related(
-    ).prefetch_related(
         'attachment',
         'created_by',
     )


### PR DESCRIPTION
ArticleViewSet list action 에서 nested_comments_count 계산하는 부분의 쿼리를 최적화했습니다.

before:
![localhost_8000_api_articles__format=json debug-toolbar (1)](https://user-images.githubusercontent.com/13573120/93690136-d7b0f080-fb0f-11ea-9b3a-0746f0971c2f.png)

after:
![localhost_8000_api_articles__format=json debug-toolbar](https://user-images.githubusercontent.com/13573120/93690133-d54e9680-fb0f-11ea-8311-b356908ae44a.png)
