### PR TITLE
Add logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ config.cnf
 
 # End of https://www.gitignore.io/api/visualstudiocode
 
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ After writing translations, run the following command to apply the translations.
 $ make i18n_compile
 ```
 
+### Create log directory
+```bash
+$ sudo mkdir -p /var/log/newara
+$ sudo chown $(whoami) /var/log/newara
+```
+
 ### Run lightweight server for development
 
 ```bash

--- a/ara/log.py
+++ b/ara/log.py
@@ -1,0 +1,97 @@
+import os
+import time
+import logging
+
+from logging import handlers
+
+
+class SizedTimedRotatingFileHandler(handlers.TimedRotatingFileHandler):
+    """
+    Handler for logging to a set of files, which switches from one file
+    to the next when the current file reaches a certain size, or at certain
+    timed intervals
+    """
+
+    def __init__(self, filename, maxBytes=0, backupCount=0, encoding=None,
+                 delay=0, when='h', interval=1, utc=False):
+        handlers.TimedRotatingFileHandler.__init__(
+            self, filename, when, interval, backupCount, encoding, delay, utc)
+        self.maxBytes = maxBytes
+
+    def shouldRollover(self, record):
+        """
+        Determine if rollover should occur.
+
+        Basically, see if the supplied record would cause the file to exceed
+        the size limit we have.
+        """
+        if self.stream is None:
+            self.stream = self._open()
+        if self.maxBytes > 0:
+            msg = "%s\n" % self.format(record)
+            # due to non-posix-compliant Windows feature
+            self.stream.seek(0, 2)
+            if self.stream.tell() + len(msg) >= self.maxBytes:
+                return 1
+        t = int(time.time())
+        if t >= self.rolloverAt:
+            return 1
+        return 0
+
+    def doRollover(self):
+        """
+        do a rollover; in this case, a date/time stamp is appended to the filename
+        when the rollover happens.  However, you want the file to be named for the
+        start of the interval, not the current time.  If there is a backup count,
+        then we have to get a list of matching filenames, sort them and remove
+        the one with the oldest suffix.
+        """
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+        # get the time that this sequence started at and make it a TimeTuple
+        currentTime = int(time.time())
+        dstNow = time.localtime(currentTime)[-1]
+        t = self.rolloverAt - self.interval
+        if self.utc:
+            timeTuple = time.gmtime(t)
+        else:
+            timeTuple = time.localtime(t)
+            dstThen = timeTuple[-1]
+            if dstNow != dstThen:
+                if dstNow:
+                    addend = 3600
+                else:
+                    addend = -3600
+                timeTuple = time.localtime(t + addend)
+
+        dfn = self.rotation_filename(self.baseFilename + '.' + time.strftime(self.suffix, timeTuple))
+
+        if self.when == 'MIDNIGHT':
+            dfn += time.strftime("." + '%H-%M-%S', time.localtime(currentTime))
+
+        self.rotate(self.baseFilename, dfn)
+        if self.backupCount > 0:
+            for s in self.getFilesToDelete():
+                os.remove(s)
+        if not self.delay:
+            self.stream = self._open()
+        newRolloverAt = self.computeRollover(currentTime)
+        while newRolloverAt <= currentTime:
+            newRolloverAt = newRolloverAt + self.interval
+        # If DST changes and midnight or weekly rollover, adjust for this.
+        if (self.when == 'MIDNIGHT' or self.when.startswith('W')) and not self.utc:
+            dstAtRollover = time.localtime(newRolloverAt)[-1]
+            if dstNow != dstAtRollover:
+                if not dstNow:  # DST kicks in before next rollover, so we need to deduct an hour
+                    addend = -3600
+                else:           # DST bows out before next rollover, so we need to add an hour
+                    addend = 3600
+                newRolloverAt += addend
+        self.rolloverAt = newRolloverAt
+
+    def exitRollover(self):
+        self.delay = True
+        if self.stream:
+            if self.stream.tell() > 0 :
+                self.doRollover()

--- a/ara/log/__init__.py
+++ b/ara/log/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+log = logging.getLogger('ara_logger')

--- a/ara/log/handler.py
+++ b/ara/log/handler.py
@@ -3,6 +3,7 @@ import time
 import logging
 import uuid
 import json
+from datetime import datetime
 from collections import OrderedDict
 
 from logging import handlers
@@ -26,7 +27,7 @@ class LogMiddlewareHandler(logging.Handler):
         return json.dumps(OrderedDict([
             ('id', str(uuid.uuid4())),
             ('level', record.levelname),
-            ('time', record.created),
+            ('time', datetime.fromtimestamp(record.created).isoformat()),
             *message.items()
         ]))
 

--- a/ara/log/handler.py
+++ b/ara/log/handler.py
@@ -1,8 +1,29 @@
 import os
 import time
 import logging
+import json
 
 from logging import handlers
+
+from ara.log.log_object import ErrorLogObject
+
+
+def message_from_record(record):
+    if isinstance(record.msg, dict) or isinstance(record.msg, str):
+        message = {'raw': record.msg}
+    elif isinstance(record.msg, Exception):
+        message = ErrorLogObject.format_exception(record.msg)
+    else:
+        message = record.msg.format()
+    return message
+
+
+class ConsoleHandler(logging.StreamHandler):
+    def format(self, record):
+        message = message_from_record(record)
+        message['level'] = record.levelname
+        message['time'] = record.created
+        return json.dumps(message)
 
 
 class SizedTimedRotatingFileHandler(handlers.TimedRotatingFileHandler):

--- a/ara/log/log_object.py
+++ b/ara/log/log_object.py
@@ -1,0 +1,88 @@
+import abc
+import traceback
+
+REQUEST_META_KEYS = ['PATH_INFO', 'HTTP_X_SCHEME', 'REMOTE_ADDR',
+                     'TZ', 'REMOTE_HOST', 'CONTENT_TYPE', 'CONTENT_LENGTH', 'HTTP_AUTHORIZATION',
+                     'HTTP_HOST', 'HTTP_USER_AGENT', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', ' HTTP_X_REQUEST_ID']
+
+
+class BaseLogObject(metaclass=abc.ABCMeta):
+    def __init__(self, request):
+        self.request = request
+
+    def format_request(self):
+        result = {
+            'method': self.request.method,
+            'meta': {key.lower(): str(value) for key, value in self.request.META.items() if key in REQUEST_META_KEYS},
+            'path': self.request.path_info
+        }
+
+        try:
+            result['data'] = {key: value for key, value in self.request.data.items()}
+        except AttributeError:
+            if self.request.method == 'GET':
+                result['data'] = self.request.GET.dict()
+            elif self.request.method == 'POST':
+                result['data'] = self.request.POST.dict()
+
+        try:
+            result['user'] = self.request.user.id
+        except AttributeError:
+            result['user'] = None
+
+        return result
+
+    @abc.abstractmethod
+    def format(self):
+        pass
+
+
+class LogObject(BaseLogObject):
+    def __init__(self, request, response):
+        super(LogObject, self).__init__(request)
+        self.response = response
+
+    def format(self):
+        return {
+            'request': self.format_request(),
+            'response': self.format_response()
+        }
+
+    def format_response(self):
+        result = {
+            'status': self.response.status_code,
+            'headers': dict(self.response.items()),
+            'charset': getattr(self.response, 'charset', None)
+        }
+        # if self.response.get('content-type', '').startswith('text/'):
+        #     result['data'] = str(self.response.content)
+        return result
+
+
+class ErrorLogObject(BaseLogObject):
+    def __init__(self, request, exception):
+        super(ErrorLogObject, self).__init__(request)
+        self.exception = exception
+
+    def format(self):
+        return {
+            'request': self.format_request(),
+            'exception': self.format_exception(self.exception)
+        }
+
+    @staticmethod
+    def exception_type(exception):
+        return str(type(exception)).split('\'')[1]
+
+    @staticmethod
+    def format_exception(exception):
+        # Supported for Python version >= 3.5
+        tb = [
+            {'file': item[0], 'line': item[1], 'method': item[2]}
+            for item in traceback.extract_tb(traceback.TracebackException.from_exception(exception).exc_traceback)
+        ]
+        return {
+            'message': str(exception),
+            'type': ErrorLogObject.exception_type(exception),
+            'traceback': tb
+        }

--- a/ara/log/middleware.py
+++ b/ara/log/middleware.py
@@ -1,0 +1,21 @@
+from . import log
+from .log_object import ErrorLogObject, LogObject
+
+
+class LoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if response.status_code == 500:
+            return response
+        if 400 <= response.status_code < 500:
+            log.warning(LogObject(request, response))
+        else:
+            log.info(LogObject(request, response))
+        return response
+
+    @staticmethod
+    def process_exception(request, exception):
+        log.error(ErrorLogObject(request, exception))

--- a/ara/settings/__init__.py
+++ b/ara/settings/__init__.py
@@ -5,6 +5,7 @@ from .aws import *
 from .sso import *
 from .redis import *
 from .scheduler import *
+from .log import *
 from .cacheops import *
 from .sentry import *
 

--- a/ara/settings/dev/__init__.py
+++ b/ara/settings/dev/__init__.py
@@ -1,4 +1,4 @@
-from ara.settings import INSTALLED_APPS, MIDDLEWARE
+from ara.settings import INSTALLED_APPS, MIDDLEWARE, LOGGING
 from ..djangorestframework import REST_FRAMEWORK
 
 DEBUG = True
@@ -27,6 +27,7 @@ REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
     'ara.authentication.CsrfExemptSessionAuthentication',
 )
 
+LOGGING['disable_existing_loggers'] = False
 
 try:
     from .local_settings import *

--- a/ara/settings/django.py
+++ b/ara/settings/django.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'ara.log.middleware.LoggingMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/ara/settings/log.py
+++ b/ara/settings/log.py
@@ -1,0 +1,45 @@
+import sys
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'django.server': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'default': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True
+        },
+        'root': {
+            'handlers': ['console'],
+            'level': 'INFO'
+        }
+    }
+}
+
+LOG_ACCESS_FILE_PATH = '/var/log/newara/http_access.log'
+LOG_ERROR_FILE_PATH = '/var/log/newara/http_error.log'
+LOG_MAX_BYTE = 1024*1024*10
+LOG_BACKUP_COUNT = 100

--- a/ara/settings/log.py
+++ b/ara/settings/log.py
@@ -9,32 +9,33 @@ LOGGING = {
             '()': 'django.utils.log.RequireDebugFalse'
         }
     },
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+        }
+    },
     'handlers': {
+        'default': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
         'console': {
             'level': 'INFO',
-            'class': 'logging.StreamHandler',
+            'class': 'ara.log.handler.ConsoleHandler',
             'stream': sys.stdout
         }
     },
     'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            'propagate': True,
-        },
-        'django.server': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
         'default': {
-            'handlers': ['console'],
+            'handlers': ['default'],
             'level': 'DEBUG',
             'propagate': True
         },
-        'root': {
+        'ara_logger': {
             'handlers': ['console'],
-            'level': 'INFO'
+            'level': 'DEBUG',
+            'propagate': False
         }
     }
 }

--- a/ara/settings/log.py
+++ b/ara/settings/log.py
@@ -1,5 +1,9 @@
 import sys
+import os
 
+LOG_FILE_PATH = os.environ.get('LOG_FILE_PATH', '/var/log/newara/http_access.log')
+LOG_MAX_BYTES = int(os.environ.get('LOG_MAX_BYTES', 1024 * 1024 * 10))
+LOG_BACKUP_COUNT = int(os.environ.get('LOG_BACKUP_COUNT', 100))
 
 LOGGING = {
     'version': 1,
@@ -27,10 +31,11 @@ LOGGING = {
         },
         'rotating_file': {
             'level': 'INFO',
-            'class': 'ara.log.handler.FileHandler',
-            'filename': '/tmp/ara.log',
+            'class': 'ara.log.handler.SizedTimedRotatingFileHandler',
+            'filename': LOG_FILE_PATH,
+            'max_bytes': LOG_MAX_BYTES,
+            'backup_count': LOG_BACKUP_COUNT,
             'when': 'midnight',
-            'backupCount': 10,
         }
     },
     'loggers': {
@@ -46,8 +51,3 @@ LOGGING = {
         }
     }
 }
-
-LOG_ACCESS_FILE_PATH = '/var/log/newara/http_access.log'
-LOG_ERROR_FILE_PATH = '/var/log/newara/http_error.log'
-LOG_MAX_BYTE = 1024*1024*10
-LOG_BACKUP_COUNT = 100

--- a/ara/settings/log.py
+++ b/ara/settings/log.py
@@ -24,6 +24,13 @@ LOGGING = {
             'level': 'INFO',
             'class': 'ara.log.handler.ConsoleHandler',
             'stream': sys.stdout
+        },
+        'rotating_file': {
+            'level': 'INFO',
+            'class': 'ara.log.handler.FileHandler',
+            'filename': '/tmp/ara.log',
+            'when': 'midnight',
+            'backupCount': 10,
         }
     },
     'loggers': {
@@ -33,7 +40,7 @@ LOGGING = {
             'propagate': True
         },
         'ara_logger': {
-            'handlers': ['console'],
+            'handlers': ['rotating_file'],
             'level': 'DEBUG',
             'propagate': False
         }

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,6 +12,8 @@ services:
       - celery_worker
     ports:
       - 9000:9000
+    volumes:
+      - /var/log/newara_api:/var/log/newara
     environment:
       - DJANGO_ENV=development
       - SECRET_KEY=
@@ -36,6 +38,8 @@ services:
     depends_on:
       - db
       - redis
+    volumes:
+      - /var/log/newara_celery:/var/log/newara
     environment:
       - DJANGO_ENV=development
       - SECRET_KEY=


### PR DESCRIPTION
로그를 추가합니다.
`/var/log`에 `newara_api`, `newara_celery`로 컨테이너별로 로그가 기록됩니다.
Celery단에서 나오는 로그들은 건드리지 않았고, 장고에서 나오는 로그들은 @victory-jooyon 님께서 작성해주신 `SizedTimedRotatingFileHandler`를 이용해서 rotating 됩니다.
로그는 JSON 형태로 포맷팅 되며, 요청별로 아래 정보가 기록됩니다.
```
{
  id: 랜덤 uuid,
  level: 로그 수준 (200이면 info, 400번대면 warning, 500번대면 error),
  time: 기록 시간 (iso 8601)
  request: {
    method: 요청 메소드,
    meta: 헤더 정보,
    path: 요청 endpoint,
    data: 요청 본문,
    user: 요청 사용자 pk (비로그인의 경우 null)
  },
  response: {
    status: 응답 status,
    headers: 헤더 정보,
    charset: charset
  }
}
```
예외가 난 경우 아래와 같이 기록됩니다.
```
{
  id: 랜덤 uuid,
  level: 로그 수준 (200이면 info, 400번대면 warning, 500번대면 error),
  time: 기록 시간 (iso 8601)
  request: {
    method: 요청 메소드,
    meta: 헤더 정보,
    path: 요청 endpoint,
    data: 요청 본문,
    user: 요청 사용자 pk (비로그인의 경우 null)
  },
  exception: {
    message: 예외 메세지,
    type: 예외 타입,
    traceback: 예외 스택 ({file, line, method}의 목록)
  }
}
```