### PR TITLE
Rollback optimize article list

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -146,4 +146,9 @@ class Article(MetaDataModel):
 
     @property
     def nested_comments_count(self):
-        return sum([self.comment_set.count(), self.comment_set__comment_set.count()])
+        from apps.core.models import Comment
+
+        return Comment.objects.filter(
+            models.Q(parent_article=self) |
+            models.Q(parent_comment__parent_article=self)
+        ).count()

--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -146,12 +146,4 @@ class Article(MetaDataModel):
 
     @property
     def nested_comments_count(self):
-        from apps.core.models import Comment
-
-        if hasattr(self, 'comment_set__count') and hasattr(self, 'comment_set__comment_set__count'):
-            return sum([self.comment_set__count, self.comment_set__comment_set__count])
-
-        return Comment.objects.filter(
-            models.Q(parent_article=self) |
-            models.Q(parent_comment__parent_article=self)
-        ).count()
+        return sum([self.comment_set.count(), self.comment_set__comment_set.count()])

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -76,9 +76,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
                 'comment_set',
                 'comment_set__comment_set',
-            ).annotate(
-                comment_set__count=models.Count('comment_set'),
-                comment_set__comment_set__count=models.Count('comment_set__comment_set'),
             )
 
         else:

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -64,12 +64,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         if self.action == 'list':
             # optimizing queryset for list action
-            queryset = queryset.select_related(
+            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
+            queryset = queryset.prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
                 'parent_board',
-            ).prefetch_related(
                 'attachments',
                 'article_update_log_set',
                 Block.prefetch_my_block(self.request.user),
@@ -83,12 +83,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         else:
             # optimizing queryset for create, update, retrieve actions
-            queryset = queryset.select_related(
+            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
+            queryset = queryset.prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
                 'parent_board',
-            ).prefetch_related(
                 'attachments',
                 Scrap.prefetch_my_scrap(self.request.user),
                 Block.prefetch_my_block(self.request.user),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -74,13 +74,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         if self.action != 'list':
             # optimizing queryset for create, update, retrieve actions
-            # cacheops 이용으로 select_related에서 prefetch_related로 옮김
             queryset = queryset.select_related(
-            ).prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
                 'parent_board',
+            ).prefetch_related(
                 'attachments',
                 Scrap.prefetch_my_scrap(self.request.user),
                 Block.prefetch_my_block(self.request.user),
@@ -112,13 +111,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
     def paginate_queryset(self, queryset):
         # optimizing queryset for list action
-        # cacheops 이용으로 select_related에서 prefetch_related로 옮김
         queryset = queryset.select_related(
-        ).prefetch_related(
             'created_by',
             'created_by__profile',
             'parent_topic',
             'parent_board',
+        ).prefetch_related(
             'attachments',
             'article_update_log_set',
             Block.prefetch_my_block(self.request.user),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -59,6 +59,16 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         ),
     }
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        if self.action == 'best':
+            queryset = queryset.filter(
+                best__isnull=False,
+            )
+
+        return queryset
+
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -65,7 +65,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         if self.action == 'list':
             # optimizing queryset for list action
             # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.prefetch_related(
+            queryset = queryset.select_related(
+            ).prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',
@@ -74,14 +75,13 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 'article_update_log_set',
                 Block.prefetch_my_block(self.request.user),
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
-                'comment_set',
-                'comment_set__comment_set',
             )
 
         else:
             # optimizing queryset for create, update, retrieve actions
             # cacheops 이용으로 select_related에서 prefetch_related로 옮김
-            queryset = queryset.prefetch_related(
+            queryset = queryset.select_related(
+            ).prefetch_related(
                 'created_by',
                 'created_by__profile',
                 'parent_topic',

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -21,9 +21,7 @@ class CommentViewSet(mixins.CreateModelMixin,
                      mixins.UpdateModelMixin,
                      mixins.DestroyModelMixin,
                      ActionAPIViewSet):
-    # cacheops 이용으로 select_related에서 prefetch_related로 옮김
     queryset = Comment.objects.select_related(
-    ).prefetch_related(
         'attachment',
         'created_by',
     )

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -21,7 +21,9 @@ class CommentViewSet(mixins.CreateModelMixin,
                      mixins.UpdateModelMixin,
                      mixins.DestroyModelMixin,
                      ActionAPIViewSet):
+    # cacheops 이용으로 select_related에서 prefetch_related로 옮김
     queryset = Comment.objects.select_related(
+    ).prefetch_related(
         'attachment',
         'created_by',
     )


### PR DESCRIPTION
https://github.com/sparcs-kaist/new-ara-api/pull/122 머지 후에 order_by('-created_at')이 적용되지 않는 것을 해결하기 위한 롤백 PR입니다.

django.db.models.Subquery, django.db.models.Count, django.db.models.OutRef 등등 다양하게 시도해보았지만 적당한 해결책이 없어서 

https://github.com/sparcs-kaist/new-ara-api/tree/feature/save-comment-count 와 같은 방식으로 해결하려 합니다.