### PR TITLE
If url, change to href

### DIFF
--- a/apps/user/views/viewsets/user.py
+++ b/apps/user/views/viewsets/user.py
@@ -38,7 +38,7 @@ def _make_random_name() -> str:
     return temp_nickname
 
 
-def _make_random_profile_picture() -> str:
+def make_random_profile_picture() -> str:
     colors = ['blue', 'red', 'gray']
     random.shuffle(colors)
     numbers = ['1', '2', '3']
@@ -120,7 +120,7 @@ class UserViewSet(ActionAPIViewSet):
 
         except UserProfile.DoesNotExist:  # 회원가입
             user_nickname = _make_random_name()
-            user_profile_picture = _make_random_profile_picture()
+            user_profile_picture = make_random_profile_picture()
             with transaction.atomic():
                 new_user = get_user_model().objects.create_user(
                     email=user_info['email'],


### PR DESCRIPTION
@HelloWorld017 가 포탈에서 크롤링해온 글들의 링크가 plain text로 나오는게 있어 하이퍼링크화 작업을 예정하고 있었는데, 프론트에서 처리하기보단 처음 긁어올때부터 백엔드에서 처리해주는게 부하가 적을 것 같아 작업했습니다.
이미 링크화가 되어있는건 태깅을 건너뛰어줘야하는데, 포탈 공지에서 그런 경우는 a 태그의 href attribute이거나 img 태그의 src attribute 두가지만 있을거라고 일단 예상하고 작업했습니다.

Help-needed:
- 혹시 링크가 이미 태그 안에 있는지 확인하는 작업을 일반화할 수 있거나,
- ~위 두가지 (a-href, img-src) 외 또 생각나는 경우가 있으시면 알려주시면 좋을 것 같습니다.~

-> recursive하게 child다 불러와서 traverse하는걸로 수정했어요.

고치고 싶었던 예시: https://ara-beta-dev.netlify.app/post/440?from_view=all 의 수강취소쪽 링크 등이 plain text로 나옴