### PR TITLE
Delete using profile.user_id

### DIFF
--- a/apps/user/serializers/user_profile.py
+++ b/apps/user/serializers/user_profile.py
@@ -58,7 +58,6 @@ class UserProfileUpdateActionSerializer(BaseUserProfileSerializer):
 class PublicUserProfileSerializer(BaseUserProfileSerializer):
     class Meta(BaseUserProfileSerializer.Meta):
         fields = (
-            'user_id',
             'picture',
             'nickname',
             'user'


### PR DESCRIPTION
profile.user_id = profile.id 라서 필요없는 중복을 없앴습니다.