### PR TITLE
Delete email field in public user serializer

### DIFF
--- a/apps/user/serializers/user.py
+++ b/apps/user/serializers/user.py
@@ -34,7 +34,6 @@ class PublicUserSerializer(BaseUserSerializer):
     class Meta(BaseUserSerializer.Meta):
         fields = (
             'id',
-            'email',
             'username',
             'profile',
         )


### PR DESCRIPTION
현재 뉴아라에서는 다른사람의 이메일을 사용하는 일이 없어 public user serializer 에서 제외합니다.