### PR TITLE
Hotfix showing wrong blocks in side articles

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -5,7 +5,7 @@ from rest_framework import exceptions, serializers
 from apps.core.documents import ArticleDocument
 from ara.classes.serializers import MetaDataModelSerializer
 
-from apps.core.models import Article, ArticleReadLog, Board
+from apps.core.models import Article, ArticleReadLog, Board, Block
 from apps.core.serializers.board import BoardSerializer
 from apps.core.serializers.topic import TopicSerializer
 
@@ -241,7 +241,7 @@ class ArticleSerializer(BaseArticleSerializer):
             if request.query_params.get('search_query'):
                 articles = self.search_articles(articles, request.query_params.get('search_query'))
 
-            articles = articles.exclude(id=obj.id)
+            articles = articles.exclude(id=obj.id).prefetch_related(Block.prefetch_my_block(request.user))
             before = articles.filter(created_at__lte=obj.created_at).first()
             after = articles.filter(created_at__gte=obj.created_at).last()
 
@@ -287,7 +287,7 @@ class ArticleSerializer(BaseArticleSerializer):
 
         recent_articles = recent_articles.exclude(
             id=obj.id,  # 자기 자신 제거
-        )
+        ).prefetch_related(Block.prefetch_my_block(request.user))
 
         # 사용자가 현재 읽고 있는 글의 바로 직전 조회 기록보다 먼저 읽은 것 중 첫 번째
         before = recent_articles.filter(


### PR DESCRIPTION
side articles에 대해 차단한 사용자들 필터링이 제대로 안되는 문제가 있어서 고쳤습니다.
prefetch_related는 queryset에만 쓸수있어서 일단 before, after를 결정하기 직전 queryset에다가 붙였는데요,
before, after에 대해서만 가져와도 되는데 비효율적인것 같아서요.

하나의 object에 대해서만 prefetch 해올 수 있는 방법은 없나요?
`Article.objects.filter(id=before_id).prefetch_related ~` 처럼
id를 다 아는상태에서 그거 하나만 든 queryset을 만들어서 가져오는것도 테스팅해봤는데 시간으로 따졌을때 더 비효율적인 것 같더라고요. (시간도 그렇고 query수가 2개 증가해요. 데이터가 아주 많은상태에서 테스트해보진 않아서 시간은 정확하지 않지만)