### PR TITLE
article view optimization

### DIFF
--- a/apps/core/management/tasks.py
+++ b/apps/core/management/tasks.py
@@ -22,7 +22,7 @@ def _get_best(days, period):
     to_ts = time.time()
     from_ts = to_ts - 24*60*60*days
 
-    vote_objs = redis.get_objs(_get_redis_key(type_), f'({from_ts}', to_ts)
+    vote_objs = redis.get_objs_by_values(_get_redis_key(type_), f'({from_ts}', to_ts)
 
     article_votes = defaultdict(int)
     for obj in vote_objs:
@@ -30,7 +30,7 @@ def _get_best(days, period):
         article_votes[article_id] += int(vote)
 
     type_ = 'hit'
-    hit_objs = redis.get_objs(_get_redis_key(type_), f'({from_ts}', to_ts)
+    hit_objs = redis.get_objs_by_values(_get_redis_key(type_), f'({from_ts}', to_ts)
 
     article_hits = defaultdict(int)
     for obj in hit_objs:

--- a/apps/core/models/article_log.py
+++ b/apps/core/models/article_log.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.db import models
 from django.conf import settings
 

--- a/apps/core/models/block.py
+++ b/apps/core/models/block.py
@@ -68,5 +68,5 @@ class Block(MetaDataModel):
 
     @staticmethod
     def is_blocked(blocked_by, user):
-        block_objs = redis.get_objs_by_values(f'blocks:{blocked_by.id}', 0, -1, (lambda x: int(x)))  # all blocks
+        block_objs = redis.get_objs_by_indexes(f'blocks:{blocked_by.id}', 0, -1, (lambda x: int(x)))  # all blocks
         return user.id in block_objs

--- a/apps/core/models/block.py
+++ b/apps/core/models/block.py
@@ -1,6 +1,9 @@
+import time
+
 from django.db import models, IntegrityError
 from django.conf import settings
 
+from ara import redis
 from ara.db.models import MetaDataModel
 
 
@@ -37,6 +40,23 @@ class Block(MetaDataModel):
 
         super(Block, self).save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
 
+        created = force_insert
+        if created:
+            pipe = redis.pipeline()
+            redis_key = f'blocks:{self.blocked_by_id}'
+
+            pipe.zadd(redis_key, {f'{self.user_id}': time.time()})
+            pipe.execute(raise_on_error=True)
+
+    def delete(self, **kwargs):
+        super().delete(**kwargs)
+
+        pipe = redis.pipeline()
+        redis_key = f'blocks:{self.blocked_by_id}'
+        pipe.zrem(redis_key, f'{self.user_id}')
+
+        pipe.execute(raise_on_error=True)
+
     @classmethod
     def prefetch_my_block(cls, user, prefix=''):
         return models.Prefetch(
@@ -45,3 +65,8 @@ class Block(MetaDataModel):
                 blocked_by=user,
             ),
         )
+
+    @staticmethod
+    def is_blocked(blocked_by, user):
+        block_objs = redis.get_objs_by_values(f'blocks:{blocked_by.id}', 0, -1, (lambda x: int(x)))  # all blocks
+        return user.id in block_objs

--- a/apps/core/models/signals/__init__.py
+++ b/apps/core/models/signals/__init__.py
@@ -1,1 +1,2 @@
 from .comment import *
+from .block import *

--- a/apps/core/models/signals/block.py
+++ b/apps/core/models/signals/block.py
@@ -1,0 +1,31 @@
+import time
+
+from django.db import models
+from django.dispatch import receiver
+from django.utils import timezone
+
+from apps.core.models import Block
+from ara import redis
+
+
+@receiver(models.signals.post_save, sender=Block)
+def block_post_save_signal(created, instance, **kwargs):
+    def add_block_to_redis(block):
+        pipe = redis.pipeline()
+        redis_key = f'blocks:{block.blocked_by_id}'
+        pipe.zadd(redis_key, {f'{block.user_id}': time.time()})
+        pipe.execute(raise_on_error=True)
+
+    def delete_block_from_redis(block):
+        pipe = redis.pipeline()
+        redis_key = f'blocks:{block.blocked_by_id}'
+        pipe.zrem(redis_key, f'{block.user_id}')
+        pipe.execute(raise_on_error=True)
+
+    deleted = instance.deleted_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
+
+    if created:
+        add_block_to_redis(instance)
+
+    elif deleted:
+        delete_block_from_redis(instance)

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -13,7 +13,8 @@ from apps.core.serializers.topic import TopicSerializer
 class BaseArticleSerializer(MetaDataModelSerializer):
     class Meta:
         model = Article
-        exclude = ('content', 'content_text', 'migrated_hit_count', 'migrated_positive_vote_count', 'migrated_negative_vote_count',)
+        exclude = ('content', 'content_text', 'attachments',
+                   'migrated_hit_count', 'migrated_positive_vote_count', 'migrated_negative_vote_count',)
 
     @staticmethod
     def get_my_vote(obj):

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -36,17 +36,6 @@ class BaseArticleSerializer(MetaDataModelSerializer):
 
         return BaseScrapSerializer(my_scrap).data
 
-    @staticmethod
-    def get_my_report(obj):
-        from apps.core.serializers.report import BaseReportSerializer
-
-        if not obj.report_set.exists():
-            return None
-
-        my_report = obj.report_set.all()[0]
-
-        return BaseReportSerializer(my_report).data
-
     def get_is_hidden(self, obj):
         if self.validate_hidden(obj):
             return True
@@ -341,9 +330,6 @@ class ArticleSerializer(BaseArticleSerializer):
         read_only=True,
     )
     my_scrap = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    my_report = serializers.SerializerMethodField(
         read_only=True,
     )
     created_by = serializers.SerializerMethodField(

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -71,14 +71,6 @@ class CommentSerializer(BaseCommentSerializer):
     created_by = PublicUserSerializer(
         read_only=True,
     )
-
-    from apps.core.serializers.comment_log import CommentUpdateLogSerializer
-    comment_update_logs = CommentUpdateLogSerializer(
-        many=True,
-        read_only=True,
-        source='comment_update_log_set',
-    )
-
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )
@@ -104,14 +96,6 @@ class CommentListActionSerializer(BaseCommentSerializer):
     created_by = PublicUserSerializer(
         read_only=True,
     )
-
-    from apps.core.serializers.comment_log import CommentUpdateLogSerializer
-    comment_update_logs = CommentUpdateLogSerializer(
-        many=True,
-        read_only=True,
-        source='comment_update_log_set',
-    )
-
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -19,17 +19,6 @@ class BaseCommentSerializer(MetaDataModelSerializer):
 
         return my_vote.is_positive
 
-    @staticmethod
-    def get_my_report(obj):
-        from apps.core.serializers.report import BaseReportSerializer
-
-        if not obj.report_set.exists():
-            return None
-
-        my_report = obj.report_set.all()[0]
-
-        return BaseReportSerializer(my_report).data
-
     def get_is_hidden(self, obj):
         if self.validate_hidden(obj):
             return True
@@ -93,9 +82,6 @@ class CommentSerializer(BaseCommentSerializer):
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )
-    my_report = serializers.SerializerMethodField(
-        read_only=True,
-    )
     is_hidden = serializers.SerializerMethodField(
         read_only=True,
     )
@@ -127,9 +113,6 @@ class CommentListActionSerializer(BaseCommentSerializer):
     )
 
     my_vote = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    my_report = serializers.SerializerMethodField(
         read_only=True,
     )
     is_hidden = serializers.SerializerMethodField(

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -2,7 +2,7 @@ from rest_framework import serializers, exceptions
 
 from ara.classes.serializers import MetaDataModelSerializer
 
-from apps.core.models import Comment
+from apps.core.models import Comment, Block
 
 
 class BaseCommentSerializer(MetaDataModelSerializer):
@@ -71,7 +71,7 @@ class BaseCommentSerializer(MetaDataModelSerializer):
     def validate_hidden(self, obj):
         errors = []
 
-        if obj.created_by.blocked_by_set.exists():
+        if Block.is_blocked(blocked_by=self.context['request'].user, user=obj.created_by):
             errors.append(exceptions.ValidationError('차단한 사용자의 게시물입니다.'))
 
         return errors

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -8,7 +8,7 @@ from apps.core.models import Comment
 class BaseCommentSerializer(MetaDataModelSerializer):
     class Meta:
         model = Comment
-        fields = '__all__'
+        exclude = ('attachment', )
 
     @staticmethod
     def get_my_vote(obj):

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -71,7 +71,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 'parent_board',
             ).prefetch_related(
                 'article_update_log_set',
-                Block.prefetch_my_block(self.request.user),
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
             )
 
@@ -101,20 +100,17 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             ).prefetch_related(
                 'attachments',
                 Scrap.prefetch_my_scrap(self.request.user),
-                Block.prefetch_my_block(self.request.user),
                 models.Prefetch(
                     'comment_set',
                     queryset=Comment.objects.reverse().prefetch_related(
                         'comment_update_log_set',
                         Vote.prefetch_my_vote(self.request.user),
-                        Block.prefetch_my_block(self.request.user),
                         Report.prefetch_my_report(self.request.user),
                         models.Prefetch(
                             'comment_set',
                             queryset=Comment.objects.reverse().prefetch_related(
                                 'comment_update_log_set',
                                 Vote.prefetch_my_vote(self.request.user),
-                                Block.prefetch_my_block(self.request.user),
                                 Report.prefetch_my_report(self.request.user),
                             ),
                         ),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -105,13 +105,11 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                     queryset=Comment.objects.reverse().prefetch_related(
                         'comment_update_log_set',
                         Vote.prefetch_my_vote(self.request.user),
-                        Report.prefetch_my_report(self.request.user),
                         models.Prefetch(
                             'comment_set',
                             queryset=Comment.objects.reverse().prefetch_related(
                                 'comment_update_log_set',
                                 Vote.prefetch_my_vote(self.request.user),
-                                Report.prefetch_my_report(self.request.user),
                             ),
                         ),
                     ),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -103,12 +103,10 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 models.Prefetch(
                     'comment_set',
                     queryset=Comment.objects.reverse().prefetch_related(
-                        'comment_update_log_set',
                         Vote.prefetch_my_vote(self.request.user),
                         models.Prefetch(
                             'comment_set',
                             queryset=Comment.objects.reverse().prefetch_related(
-                                'comment_update_log_set',
                                 Vote.prefetch_my_vote(self.request.user),
                             ),
                         ),

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -70,7 +70,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 'parent_topic',
                 'parent_board',
             ).prefetch_related(
-                'attachments',
                 'article_update_log_set',
                 Block.prefetch_my_block(self.request.user),
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
@@ -105,18 +104,14 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 Block.prefetch_my_block(self.request.user),
                 models.Prefetch(
                     'comment_set',
-                    queryset=Comment.objects.reverse().select_related(
-                        'attachment',
-                    ).prefetch_related(
+                    queryset=Comment.objects.reverse().prefetch_related(
                         'comment_update_log_set',
                         Vote.prefetch_my_vote(self.request.user),
                         Block.prefetch_my_block(self.request.user),
                         Report.prefetch_my_report(self.request.user),
                         models.Prefetch(
                             'comment_set',
-                            queryset=Comment.objects.reverse().select_related(
-                                'attachment',
-                            ).prefetch_related(
+                            queryset=Comment.objects.reverse().prefetch_related(
                                 'comment_update_log_set',
                                 Vote.prefetch_my_vote(self.request.user),
                                 Block.prefetch_my_block(self.request.user),

--- a/apps/core/views/viewsets/block.py
+++ b/apps/core/views/viewsets/block.py
@@ -44,7 +44,6 @@ class BlockViewSet(mixins.ListModelMixin,
 
     @decorators.action(detail=False, methods=['post'])
     def without_id(self, request, *args, **kwargs):
-        print('request', request)
         instance = Block.objects.get(blocked_by=request.user, user=request.data.get('blocked'))
         self.perform_destroy(instance)
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/core/views/viewsets/report.py
+++ b/apps/core/views/viewsets/report.py
@@ -49,8 +49,6 @@ class ReportViewSet(mixins.ListModelMixin,
             'parent_article__comment_set__comment_set',
             'parent_article__attachments',
             'parent_article__article_update_log_set',
-            Block.prefetch_my_block(self.request.user, prefix='parent_article__'),
-            Block.prefetch_my_block(self.request.user, prefix='parent_comment__'),
             ArticleReadLog.prefetch_my_article_read_log(self.request.user, prefix='parent_article__'),
         )
 

--- a/apps/core/views/viewsets/scrap.py
+++ b/apps/core/views/viewsets/scrap.py
@@ -45,7 +45,6 @@ class ScrapViewSet(mixins.ListModelMixin,
             'parent_article__comment_set__comment_set',
             'parent_article__attachments',
             'parent_article__article_update_log_set',
-            Block.prefetch_my_block(self.request.user, prefix='parent_article__'),
             ArticleReadLog.prefetch_my_article_read_log(self.request.user, prefix='parent_article__'),
         )
 

--- a/ara/redis.py
+++ b/ara/redis.py
@@ -38,16 +38,26 @@ class PrefixedRedis(PyRedis):
     def zadd(self, name, mapping, **kwargs):
         return super().zadd(f'{self.key_prefix}{name}', mapping, **kwargs)
 
+    def zrem(self, name, value, **kwargs):
+        return super().zrem(f'{self.key_prefix}{name}', name, value)
+
     def zrange(self, name, start, end, **kwargs):
         return super().zrange(f'{self.key_prefix}{name}', start, end, **kwargs)
 
     def zrangebyscore(self, name, min, max, **kwargs):
         return super().zrangebyscore(f'{self.key_prefix}{name}', min, max, **kwargs)
 
-    def get_objs(self, name, from_ts, to_ts):
+    def get_objs_by_values(self, name, from_value, to_value, preprocess=(lambda x: x)):
         objs = []
-        for row in self.zrangebyscore(name, from_ts, to_ts):
-            objs.append(row.decode())
+        for row in self.zrangebyscore(name, from_value, to_value):
+            objs.append(preprocess(row.decode()))
+
+        return objs
+
+    def get_objs_by_indexes(self, name, from_index, to_index, preprocess=(lambda x: x)):
+        objs = []
+        for row in self.zrange(name, from_index, to_index):
+            objs.append(preprocess(row.decode()))
 
         return objs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from django.test import TestCase as DjangoTestCase
 from rest_framework.test import APIClient
 
 from apps.user.models import UserProfile
+from ara import redis
 
 
 @pytest.fixture(scope='class')
@@ -62,7 +63,9 @@ class RequestSetting:
 class TestCase(DjangoTestCase):
     @classmethod
     def setUpClass(cls):
+        redis.flushall()
         super().setUpClass()
 
     def tearDown(self):
+        redis.flushall()
         super().tearDown()

--- a/tests/test_article_search.py
+++ b/tests/test_article_search.py
@@ -1,11 +1,11 @@
 import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase, TransactionTestCase
 
 from apps.core.models import Board, Article
 from apps.user.models import UserProfile
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
+
 
 # TODO: test_articles fixture와 중복되는 코드 합치기
 
@@ -66,11 +66,11 @@ def set_index(request):
 
 
 @pytest.mark.usefixtures('set_user_client', 'set_index', 'set_board', 'set_authors', 'set_posts')
-class TestArticleSearch(TransactionTestCase, RequestSetting):
+class TestArticleSearch(TestCase, RequestSetting):
     def test_main_search(self):
         # `main_search` 필터를 검사합니다. 개수 assertion 숫자들의 의미는 set_posts를 참고하세요.
 
-        def get_searched_article_number(q): 
+        def get_searched_article_number(q):
             return self.http_request(
                 self.user,
                 'get',
@@ -79,7 +79,7 @@ class TestArticleSearch(TransactionTestCase, RequestSetting):
             ).data['num_items']
 
         wanted_min_proportion = 0.9
-        
+
         queries = [
             ('AAAA', 34),
             ('BBBB', 20),

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -1,11 +1,10 @@
 import pytest
 from django.contrib.auth.models import User
-from django.test import TestCase
 from django.utils import timezone
 
 from apps.core.models import Article, Topic, Board
 from apps.user.models import UserProfile
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,10 +1,9 @@
 import pytest
 from django.db import transaction
-from django.test import TestCase
 from django.utils import timezone
 from django.db.utils import IntegrityError
 from apps.core.models import Article, Topic, Board, Comment, Block
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,8 +1,6 @@
 import pytest
-from django.test import TestCase
-
 from apps.core.models import Board
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.mark.usefixtures('set_user_client')

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,8 +1,7 @@
 import pytest
-from django.test import TestCase
 from django.utils import timezone
-from apps.core.models import Article, ArticleReadLog, Topic, Board, Comment
-from tests.conftest import RequestSetting
+from apps.core.models import Article, Topic, Board, Comment
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,7 +1,6 @@
 import pytest
-from django.test import TestCase
 
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.mark.usefixtures('set_user_client')

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,6 +1,5 @@
 import pytest
-from django.test import TestCase
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 from apps.core.models import Notification, NotificationReadLog, Article, Board, Comment
 

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,7 +1,6 @@
 import pytest
-from django.test import TestCase
 from apps.core.models import Article, Topic, Board, Comment, Report
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 from django.utils import timezone
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,8 +1,7 @@
 import pytest
-from django.test import TestCase
 from apps.core.models import Article, Topic, Board, Comment, Report
 from django.db.utils import IntegrityError
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 from django.utils import timezone
 
 

--- a/tests/test_scrap.py
+++ b/tests/test_scrap.py
@@ -1,7 +1,6 @@
 import pytest
 from django.db import IntegrityError, transaction
-from django.test import TestCase
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 from apps.core.models import Scrap, Board, Article, Block
 
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,11 +1,10 @@
 from datetime import timedelta
 
 import pytest
-from django.test import TestCase
 from django.utils import timezone
 
 from apps.core.models import Board, Article
-from tests.conftest import RequestSetting
+from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
- [x] list에서 안쓰는 prefetch 제거하기
- [ ] list에서 중복된 prefetch 다 제거하기
- [x] list에서 쓰는 필드만 들고오기
- [x] block은 cache해서 쓰기
- [ ] 말도 안되는 조인 하지 말고, comment count 필드 쓰기 -> @talkwithraon 님 진행중
- [ ] detail에서 comment 불러오는 쿼리 prefetch 적용되게 하기
- [ ] query cache 안먹는 중복 filter_queryset 제거하기
- [ ] read log 다 들고 오지 말고 last read at으로 annotate 하기
- [x] update log 들고오지말고 updated_at 이용