### PR TITLE
Add defensive code for avoiding try to logout with anonymous user

### DIFF
--- a/apps/user/views/viewsets/user.py
+++ b/apps/user/views/viewsets/user.py
@@ -190,12 +190,13 @@ class UserViewSet(ActionAPIViewSet):
 
     @decorators.action(detail=True, methods=['delete'])
     def sso_logout(self, request, *args, **kwargs):
-        logout(request)
-        # In case of user who isn't logged in with Sparcs SSO
-        if not request.user.profile.sid:
-            return response.Response(
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if request.user.is_authenticated:
+            logout(request)
+            # In case of user who isn't logged in with Sparcs SSO
+            if not request.user.profile.sid:
+                return response.Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         return self.sso_client.get_logout_url(
             sid=request.user.profile.sid,


### PR DESCRIPTION
로그아웃된 상태에서 한 번 더 로그아웃을 시도할 때 500 Internal Server Error가 나는 것을 방지하는 코드입니다.

일반적인 상황에서는 발생하지 않지만, 방어적인 프로그래밍 차원에서 넣었습니다.