### PR TITLE
Cascade soft deletion with collector

### DIFF
--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -56,8 +56,10 @@ class MetaDataModel(models.Model):
         self.deleted_at = timezone.now()
         self.save()
 
-    def hard_delete(self):
-        super().delete()
+    def hard_delete(self, using=None, keep_parents=False):
+        return super().delete(using=using, keep_parents=keep_parents)
+
+    hard_delete.alters_data = True
 
 
 class Search(models.Lookup):

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -26,6 +26,11 @@ class MetaDataManager(models.Manager):
         return self.queryset_class(self.model).filter(deleted_at=timezone.datetime.min.replace(tzinfo=timezone.utc))
 
 
+class MetaDataCollector(models.deletion.Collector):
+    def hard_delete(self):
+        return super().delete()
+
+
 # TODO: add redis to metadatamodel
 class MetaDataModel(models.Model):
     class Meta:

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -60,11 +60,11 @@ class MetaDataModel(models.Model):
     def delete(self, using=None, keep_parents=False):
         using = using or router.db_for_write(self.__class__, instance=self)
         assert self.pk is not None, (
-                "%s object can't be deleted because its %s attribute is set to None." %
-                (self._meta.object_name, self._meta.pk.attname)
+            "%s object can't be deleted because its %s attribute is set to None." %
+            (self._meta.object_name, self._meta.pk.attname)
         )
 
-        # collector = Collector(using=using)
+        # Changed in MetaDataModel: collector = Collector(using=using)
         collector = MetaDataCollector(using=using)
         collector.collect([self], keep_parents=keep_parents)
         return collector.delete()

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -52,6 +52,81 @@ class MetaDataManager(models.Manager):
 
 
 class MetaDataCollector(models.deletion.Collector):
+    def delete(self):
+        # sort instance collections
+        for model, instances in self.data.items():
+            self.data[model] = sorted(instances, key=attrgetter("pk"))
+
+        # if possible, bring the models in an order suitable for databases that
+        # don't support transactions or cannot defer constraint checks until the
+        # end of a transaction.
+        self.sort()
+        # number of objects deleted for each model label
+        deleted_counter = Counter()
+
+        # Optimize for the case with a single obj and no dependencies
+        if len(self.data) == 1 and len(instances) == 1:
+            instance = list(instances)[0]
+            if self.can_fast_delete(instance):
+                with transaction.mark_for_rollback_on_error(self.using):
+                    # Changed in MetaDataCollector:
+                    # count = sql.DeleteQuery(model).delete_batch([instance.pk], self.using)
+                    count = instance.delete(using=self.using)
+                setattr(instance, model._meta.pk.attname, None)
+                return count, {model._meta.label: count}
+
+        with transaction.atomic(using=self.using, savepoint=False):
+            # send pre_delete signals
+            for model, obj in self.instances_with_model():
+                if not model._meta.auto_created:
+                    signals.pre_delete.send(
+                        sender=model, instance=obj, using=self.using
+                    )
+
+            # fast deletes
+            for qs in self.fast_deletes:
+                # Changed in MetaDataCollector: count = qs._raw_delete(using=self.using)
+                count = qs.delete(using=self.using)
+                if count:
+                    deleted_counter[qs.model._meta.label] += count
+
+            # update fields
+            for model, instances_for_fieldvalues in self.field_updates.items():
+                for (field, value), instances in instances_for_fieldvalues.items():
+                    query = sql.UpdateQuery(model)
+                    query.update_batch([obj.pk for obj in instances],
+                                       {field.name: value}, self.using)
+
+            # reverse instance collections
+            for instances in self.data.values():
+                instances.reverse()
+
+            # delete instances
+            for model, instances in self.data.items():
+                # Changed in MetaDataCollector:
+                # query = sql.DeleteQuery(model)
+                # pk_list = [obj.pk for obj in instances]
+                # count = query.delete_batch(pk_list, self.using)
+                count = instances.delete()
+                if count:
+                    deleted_counter[model._meta.label] += count
+
+                if not model._meta.auto_created:
+                    for obj in instances:
+                        signals.post_delete.send(
+                            sender=model, instance=obj, using=self.using
+                        )
+
+        # update collected instances
+        for instances_for_fieldvalues in self.field_updates.values():
+            for (field, value), instances in instances_for_fieldvalues.items():
+                for obj in instances:
+                    setattr(obj, field.attname, value)
+        for model, instances in self.data.items():
+            for instance in instances:
+                setattr(instance, model._meta.pk.attname, None)
+        return sum(deleted_counter.values()), dict(deleted_counter)
+
     def hard_delete(self):
         return super().delete()
 

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -1,4 +1,9 @@
-from django.db import models
+from collections import Counter
+from operator import attrgetter
+
+from django.db import models, router
+from django.db import transaction
+from django.db.models import signals, sql
 from django.utils import timezone
 
 

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -4,9 +4,34 @@ from django.utils import timezone
 
 class MetaDataQuerySet(models.QuerySet):
     def delete(self):
-        return super().update(**{
-            'deleted_at': timezone.now(),
-        })
+        """Delete the records in the current QuerySet."""
+        self._not_support_combined_queries('delete')
+        assert not self.query.is_sliced, \
+            "Cannot use 'limit' or 'offset' with delete."
+
+        if self._fields is not None:
+            raise TypeError("Cannot call delete() after .values() or .values_list()")
+
+        del_query = self._chain()
+
+        # The delete is actually 2 queries - one to find related objects,
+        # and one to delete. Make sure that the discovery of related
+        # objects is performed on the same database as the deletion.
+        del_query._for_write = True
+
+        # Disable non-supported fields.
+        del_query.query.select_for_update = False
+        del_query.query.select_related = False
+        del_query.query.clear_ordering(force_empty=True)
+
+        # Changed in MetaDataQuerySet: collector = Collector(using=del_query.db)
+        collector = MetaDataCollector(using=del_query.db)
+        collector.collect(del_query)
+        deleted, _rows_count = collector.delete()
+
+        # Clear the result cache, in case this QuerySet gets reused.
+        self._result_cache = None
+        return deleted, _rows_count
 
     def hard_delete(self):
         return super().delete()

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -53,8 +53,18 @@ class MetaDataModel(models.Model):
     )
 
     def delete(self, using=None, keep_parents=False):
-        self.deleted_at = timezone.now()
-        self.save()
+        using = using or router.db_for_write(self.__class__, instance=self)
+        assert self.pk is not None, (
+                "%s object can't be deleted because its %s attribute is set to None." %
+                (self._meta.object_name, self._meta.pk.attname)
+        )
+
+        # collector = Collector(using=using)
+        collector = MetaDataCollector(using=using)
+        collector.collect([self], keep_parents=keep_parents)
+        return collector.delete()
+
+    delete.alters_data = True
 
     def hard_delete(self, using=None, keep_parents=False):
         return super().delete(using=using, keep_parents=keep_parents)


### PR DESCRIPTION
사용하지 않을 수도 있는 Collector를 사용한 Cascade Soft Deletion 구현.

"# Changed in"을 검색하면서 보시면, 기존의 django 구현체들과 어떤 점이 달라졌는지 쉽게 확인하실 수 있습니다.

test case는 나중에 수정함