### PR TITLE
Limit result of main_search size to 500

### DIFF
--- a/apps/core/documents.py
+++ b/apps/core/documents.py
@@ -2,7 +2,8 @@ from django.conf import settings
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 from django.apps import apps
-from elasticsearch_dsl import analyzer, tokenizer
+from elasticsearch_dsl import analyzer, tokenizer, Q
+from elasticsearch_dsl.query import Query
 from elasticsearch_dsl.analysis import token_filter
 
 from apps.core.models import Article
@@ -74,12 +75,18 @@ class ArticleDocument(Document):
         return super(ArticleDocument, self).get_queryset().prefetch_related('created_by').prefetch_related('created_by__profile')
 
     @staticmethod
-    def get_id_set(field_name, search_value):
+    def get_id_set(q_object : Query):
         return [
             x.meta.id
             for x
-            in ArticleDocument.search().filter('match', **{field_name: search_value})[0:200].execute()
+            in ArticleDocument.search().query(q_object).sort('-created_at')[0:500].execute()
         ]
+
+    @staticmethod
+    def get_main_search_id_set(value):
+        return ArticleDocument.get_id_set(
+            Q('match', title=value) | Q('match', content_text=value) | Q('match', created_by_nickname=value)
+        )
 
     @staticmethod
     def get_instances_from_related(related_instance):

--- a/apps/core/documents.py
+++ b/apps/core/documents.py
@@ -78,7 +78,7 @@ class ArticleDocument(Document):
         return [
             x.meta.id
             for x
-            in ArticleDocument.search().filter('match', **{field_name: search_value}).scan()
+            in ArticleDocument.search().filter('match', **{field_name: search_value})[0:200].execute()
         ]
 
     @staticmethod

--- a/apps/core/filters/article.py
+++ b/apps/core/filters/article.py
@@ -57,10 +57,4 @@ class ArticleFilter(filters.FilterSet):
 
     @staticmethod
     def get_main_search__contains(queryset, name, value):
-
-        title_articles = queryset.filter(id__in=ArticleDocument.get_id_set('title', value))
-        content_articles = queryset.filter(id__in=ArticleDocument.get_id_set('content_text', value))
-        nickname_articles = queryset.filter(id__in=ArticleDocument.get_id_set('created_by_nickname', value))
-        qs = title_articles | content_articles | nickname_articles
-
-        return qs.distinct()
+        return queryset.filter(id__in=ArticleDocument.get_main_search_id_set(value))

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -170,12 +170,7 @@ class ArticleSerializer(BaseArticleSerializer):
 
     @staticmethod
     def search_articles(queryset, search):
-        title_articles = queryset.filter(id__in=ArticleDocument.get_id_set('title', search))
-        content_articles = queryset.filter(id__in=ArticleDocument.get_id_set('content_text', search))
-        nickname_articles = queryset.filter(id__in=ArticleDocument.get_id_set('created_by_nickname', search))
-        qs = title_articles | content_articles | nickname_articles
-
-        return qs.distinct()
+        return queryset.filter(id__in=ArticleDocument.get_main_search_id_set(search))
 
     @staticmethod
     def filter_articles(obj, request):


### PR DESCRIPTION
main_search에 붙어 있는 로직을 elasticsearch query로 처리하도록 수정했습니다. 
apps.core.documents의 ArticleDocument.get_main_search_id_set에서 반환되는 검색결과 개수를 최대 500개로 제한하여, 실행이 적절한 시간 안에 끝나도록 합니다. 