### PR TITLE
Ensure CSRF token is set by /api/me

### DIFF
--- a/apps/user/views/me.py
+++ b/apps/user/views/me.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from apps.user.models.user_profile import UserProfile
-from apps.user.permissions.user_profile import UserProfilePermission
 from apps.user.serializers.user_profile import UserProfileSerializer
 
 from django.utils.decorators import method_decorator

--- a/apps/user/views/me.py
+++ b/apps/user/views/me.py
@@ -1,19 +1,22 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework import status
 
 from apps.user.models.user_profile import UserProfile
 from apps.user.permissions.user_profile import UserProfilePermission
 from apps.user.serializers.user_profile import UserProfileSerializer
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 
 class MeView(APIView):
     """
     Get my information from token
     """
-    permission_classes = (
-        UserProfilePermission,
-    )
-
+    @method_decorator(ensure_csrf_cookie)
     def get(self, request):
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
         serializer = UserProfileSerializer(UserProfile.objects.get(user_id=request.user.id))
         return Response(serializer.data)


### PR DESCRIPTION
CSRF 토큰이 셋팅되지 않은 상태에서 일부 요청이 보내져 오류가 나는 상황이 있습니다.
이를 해결하기 위해 클라이언트에서 한번쯤 보낼 요청 (`/api/me`)에서 csrf 토큰을 설정하도록 했습니다.

Permission을 쓰면 로그인 되지 않은 상태에서 토큰 설정이 되지 않아 뷰에서 직접 권한을 체크하도록 변경했습니다.