### PR TITLE
중복 닉네임에 번호 대신 해쉬를 부여

### DIFF
--- a/apps/user/views/viewsets/user.py
+++ b/apps/user/views/viewsets/user.py
@@ -17,6 +17,8 @@ from ara.classes.sparcssso import Client as SSOClient
 from apps.user.models import UserProfile
 from apps.user.permissions.user import UserPermission
 
+import hashlib
+
 
 def _make_random_name() -> str:
     nouns = ['외계인', '펭귄', '코뿔소', '여우', '염소', '타조', '사과', '포도', '다람쥐', '도토리', '해바라기', '코끼리', '돌고래', '거북이', '나비', '앵무새', '알파카', '강아지', '고양이', '원숭이', '두더지', '낙타', '망아지', '시조새', '힙스터', '로봇', '감자', '고구마', '가마우지', '직박구리', '오리너구리', '보노보', '개미핥기', '치타', '사자', '구렁이', '도마뱀', '개구리', '올빼미', '부엉이']
@@ -25,14 +27,13 @@ def _make_random_name() -> str:
     random.shuffle(adjectives)
     temp_nickname = adjectives[0] + ' ' + nouns[0]
     try:
-        duplicate_user_profile = UserProfile.objects.get(
-            nickname=temp_nickname,
-        )
-        tmparr = str(duplicate_user_profile.nickname).split(' ')
-        if len(tmparr) == 3:
-            temp_nickname += ' ' + str(int(tmparr[-1]) + 1)
-        else:
-            temp_nickname += ' 1'
+        UserProfile.objects.get(nickname=temp_nickname)
+        random_value = str(timezone.datetime.now().timestamp())
+        sha1 = hashlib.sha256()
+        sha1.update(bytes(random_value, 'utf-8'))
+        sha1.update(bytes(temp_nickname, 'utf-8'))
+        temp_nickname += '_' + sha1.hexdigest()[:4]
+
     except UserProfile.DoesNotExist:
         pass
     return temp_nickname


### PR DESCRIPTION
중복 닉네임의 경우 `즐거운 펭귄` -> `즐거운 펭귄_0a7b` 와 같이 해쉬를 붙여주도록 변경했습니다.
보안이 필요한 해쉬는 아니니 타임스탬프와 기존 닉네임만 이용해서 sha-256 해쉬를 만들고, 맨 앞 4자리만 붙여줬습니다.

테스트 케이스를 추가해줘야 하는데, `_make_random_name` 자체가 랜덤이다 보니 붙이기가 굉장히 애매하네요. 의견 부탁드립니다 🙏
