### PR TITLE
Fix/logout error

### DIFF
--- a/apps/user/views/viewsets/user.py
+++ b/apps/user/views/viewsets/user.py
@@ -205,13 +205,7 @@ class UserViewSet(ActionAPIViewSet):
     def sso_logout(self, request, *args, **kwargs):
         if request.user.is_authenticated:
             logout(request)
-            # In case of user who isn't logged in with Sparcs SSO
-            if not request.user.profile.sid:
-                return response.Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
 
-        return self.sso_client.get_logout_url(
-            sid=request.user.profile.sid,
-            redirect_uri=request.GET.get('next', 'https://sparcssso.kaist.ac.kr/'),
+        return response.Response(
+            status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
1. 현재 프론트엔드를 통해 접속하는 모든 사용자는 sparcs sso 로그인을 사용함. sparcs sso 외의 사용자는 고려할 필요 없음.

2. newara에서 로그아웃 한다고 sparcs sso에서도 로그아웃을 강제할 필요 없음.

3. 기존의 버그는 logout된 상태에서(AnonymousUser가 된 상태에서) user의 profile을 찾으려고 해서 발생하는 에러였음.