### PR TITLE
HomeView 퍼미션 추가

### DIFF
--- a/apps/core/views/home.py
+++ b/apps/core/views/home.py
@@ -1,10 +1,14 @@
 from rest_framework import views, response
+from rest_framework.decorators import permission_classes
+from rest_framework.permissions import IsAuthenticated
 
 from apps.core.models import BestArticle, PERIOD_CHOICES
 from apps.core.serializers.article import BestArticleListActionSerializer
 
 
 class HomeView(views.APIView):
+    permission_classes = [IsAuthenticated]
+
     def get(self, request):
         return response.Response(data={
             'daily_bests': _best_articles('daily', request),

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,0 +1,12 @@
+import pytest
+from tests.conftest import RequestSetting, TestCase
+
+
+@pytest.mark.usefixtures('set_user_client')
+class TestHome(TestCase, RequestSetting):
+    def test_board_perm(self):
+        r = self.http_request(self.user, 'get', 'home')
+        assert r.status_code == 200
+
+        r = self.http_request(None, 'get', 'home')
+        assert r.status_code == 401


### PR DESCRIPTION
로그인되어 있지 않은 상태에서 `/api/home` 요청을 보냈을 때
```
'AnonymousUser' object has no attribute 'profile'
```
오류가 발생하는 것을 수정하였습니다.
참고로 해당 이슈의 직접적인 원인은 `BaseArticleSerializer`의 `validate_hidden`에서 비로그인 상태에 대한 고려가 없어 발생하는 문제입니다. 향후 비로그인 상태에서 해당 serializer를 사용해야 한다면 수정이 필요합니다.
