### PR TITLE
Remove not exists fields

### DIFF
--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -74,8 +74,6 @@ class ArticleAdmin(MetaDataModelAdmin):
     search_fields = (
         'title',
         'content',
-        'ko_description',
-        'en_description',
     )
 
 


### PR DESCRIPTION
ko_description과 en_description은 Article에 존재하지 않는 필드이나, 복붙하면서 실수로 들어간 듯 함.