### PR TITLE
Handle not logged in user

### DIFF
--- a/apps/core/views/viewsets/notification.py
+++ b/apps/core/views/viewsets/notification.py
@@ -17,6 +17,9 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet, ActionAPIViewSet):
     }
 
     def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return Notification.objects.none()
+        
         queryset = super().get_queryset()
 
         queryset = queryset.filter(


### PR DESCRIPTION
로그인 하지 않은 사용자가 NotificationViewSet의 List나 Detail api 호출 시에 발생하는 에러 해결.

어떤 과정으로 해당 API를 호출하는지는 잘 모르겠음