### PR TITLE
유저 이메일 필드는 웬만하면 카이스트 메일로 박기

### DIFF
--- a/apps/user/views/viewsets/user.py
+++ b/apps/user/views/viewsets/user.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 import random
 from urllib.parse import urlparse
@@ -133,9 +134,18 @@ class UserViewSet(ActionAPIViewSet):
         except UserProfile.DoesNotExist:  # 회원가입
             user_nickname = _make_random_name()
             user_profile_picture = make_random_profile_picture()
+            email = user_info['email']
+
+            if email.split('@')[-1] == 'sso.sparcs.org':  # sso에서 random하게 만든 이메일인 경우
+                kaist_info = user_info['kaist_info']
+                if kaist_info:  # SNS 회원가입 후 카이생 인증
+                    kaist_info = json.loads(kaist_info)
+                    kaist_email = kaist_info['mail']
+                    email = kaist_email
+
             with transaction.atomic():
                 new_user = get_user_model().objects.create_user(
-                    email=user_info['email'],
+                    email=email,
                     username=str(uuid.uuid4()),
                     password=str(uuid.uuid4()),
                     is_active=is_kaist or is_manual,


### PR DESCRIPTION
SSO 쪽에서 SNS로 우선 회원가입을 진행하고, 그 이후에 카이스트 인증을 한 경우,
이메일은 @sso.sparcs.org 로 끝나는 랜덤 이메일이 박히고, 나중에 kaist_info 만 채워지는 듯 합니다.
카이스트 구성원임이 인증된 경우, 유저 이메일에는 웬만하면 카이스트 메일이 박히는 것이 좋은 것 같아 (마이페이지에서 볼때에도) 다음을 추가합니다.