### PR TITLE
Handle case of Vote already deleted by other previous vote_cancel action

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -173,10 +173,11 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def vote_cancel(self, request, *args, **kwargs):
         article = self.get_object()
 
-        vote = Vote.objects.filter(
+        vote = Vote.objects.get(
             voted_by=request.user,
             parent_article=article,
-        ).delete()
+        )
+        vote.delete()
 
         article.update_vote_status()
 

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -173,6 +173,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def vote_cancel(self, request, *args, **kwargs):
         article = self.get_object()
 
+        if not Vote.objects.filter(
+            voted_by=request.user,
+            parent_article=article,
+        ).exists():
+            return response.Response(status=status.HTTP_200_OK)
+
         vote = Vote.objects.get(
             voted_by=request.user,
             parent_article=article,

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -173,11 +173,10 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def vote_cancel(self, request, *args, **kwargs):
         article = self.get_object()
 
-        vote = Vote.objects.get(
+        vote = Vote.objects.filter(
             voted_by=request.user,
             parent_article=article,
-        )
-        vote.delete()
+        ).delete()
 
         article.update_vote_status()
 


### PR DESCRIPTION
좋아요 취소 버튼이나 싫어요 취소 버튼을 빠른 시간 내에 여러번 클릭해 vote_cancel action이 여러 번 발생했을 때 Vote.DoesNotExist exception이 발생하지 않도록 변경하였습니다.