### PR TITLE
Feature/handle suspicious response

### DIFF
--- a/apps/core/templates/invalid_sso_login.html
+++ b/apps/core/templates/invalid_sso_login.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+
+    <title>Oops!</title>
+    <style>
+      html {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body class="h-100">
+    <div class="d-flex justify-content-center h-100">
+      <div class="align-self-center">
+        <div class="text-center mb-4">
+          <img src="https://i.pinimg.com/originals/d3/a7/38/d3a738413b1b9c65333276c89ed82476.gif" />
+        </div>
+        <div class="alert alert-secondary" role="alert">
+          <h4 class="alert-heading">Oops!</h4>
+          <p>
+            <strong>Ara에 로그인 하는 중에 문제가 발생했습니다.</strong>
+            <br>
+            아래와 같은 원인에 의해 문제가 발생했을 수 있습니다.
+          </p>
+
+          <ul>
+            <li>SPARCS SSO 에 facebook 계정으로 로그인 하였음.
+              <ul>
+                <li><strong>SPARCS SSO 에서 로그아웃 하신 후에 facebook 대신 KAIST IAM (통합인증)으로 로그인해보세요.</strong></li>
+              </ul>
+            </li>
+            <li>
+              로그인 과정이 지연되어서 토큰이 만료됨.
+              <ul>
+                <li><strong>SPARCS SSO 에서 로그아웃 하신 후에 다시 로그인해보세요.</strong></li>
+              </ul>
+            </li>
+          </ul>
+          <p>
+            문제가 반복될 경우 new-ara@sparcs.org 에 아래의 에러 정보를 포함해 문의 부탁드립니다.
+            <br>
+            <code>code: {{ code }}, status_code: {{ status_code }}</code>
+          </p>
+          <hr>
+          <p class="mb-0">
+            <a href="https://sparcssso.kaist.ac.kr/" class="btn btn-link px-0">
+              SPARCS SSO 으로 이동
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path('api/home/', view=HomeView.as_view(), name='HomeView'),
     path('api/status/', view=StatusView.as_view(), name='StatusView'),
 
-    path('invalid_sso_login/', InvalidSsoLoginView.as_view(), name='InvalidSsoLoginView'),
+    path('api/invalid_sso_login/', InvalidSsoLoginView.as_view(), name='InvalidSsoLoginView'),
 ]

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path, include
 
-from apps.core.views import HomeView, StatusView, router
+from apps.core.views import HomeView, InvalidSsoLoginView, StatusView, router
 
 urlpatterns = [
     path('api/', include(router.urls)),
     path('api/home/', view=HomeView.as_view(), name='HomeView'),
     path('api/status/', view=StatusView.as_view(), name='StatusView'),
+
+    path('invalid_sso_login/', InvalidSsoLoginView.as_view(), name='InvalidSsoLoginView'),
 ]

--- a/apps/core/views/__init__.py
+++ b/apps/core/views/__init__.py
@@ -1,3 +1,4 @@
 from .home import *
 from .status import *
 from .router import *
+from .invalid_sso_login import InvalidSsoLoginView

--- a/apps/core/views/invalid_sso_login.py
+++ b/apps/core/views/invalid_sso_login.py
@@ -1,0 +1,20 @@
+from django.views.generic import TemplateView
+
+
+class InvalidSsoLoginView(TemplateView):
+    template_name = 'invalid_sso_login.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # TODO: code 와 status_code 에 따라 다른 해결 방법을 제시할 수 있으면 좋겠습니다.
+        # INVALID_METHOD, INVALID_CODE, TOKEN_SERVICE_MISMATCH,
+        # TOKEN_EXPIRED, INVALID_SERVICE, INALID_TIMESTAMP, INVALID_SIGN
+        # 등의 code 가 있을 수 있습니다.
+        # https://github.com/sparcs-kaist/sparcssso/blob/master/apps/api/views/v2.py
+        context.update({
+            'code': self.request.GET.get('code', ''),
+            'status_code': self.request.GET.get('status_code', ''),
+        })
+
+        return context

--- a/ara/classes/middleware.py
+++ b/ara/classes/middleware.py
@@ -6,7 +6,8 @@ class CheckTermsOfServiceMiddleware:
         'me',
         'user-sso-login',
         'user-sso-login-callback',
-        'userprofile-agree-terms-of-service'
+        'userprofile-agree-terms-of-service',
+        'InvalidSsoLoginView',
     ]
 
     def __init__(self, get_response):

--- a/ara/classes/sparcssso.py
+++ b/ara/classes/sparcssso.py
@@ -73,7 +73,8 @@ class Client:
             r.raise_for_status()
 
         except requests.exceptions.HTTPError as http_error:
-            capture_exception(http_error)
+            if int(http_error.response.status_code) >= 500:
+                capture_exception(http_error)
 
             raise http_error
 


### PR DESCRIPTION
new-ara 에 sparcs sso 로 로그인 할 때 아래의 순서대로 이동을 하면서 로그인이 진행됩니다.
new-ara-web => new-ara-api 의 sso-login view => sparcs sso => new-ara-api 의 sso-login-callback view => new-ara-web

현재는 new-ara-api 의 sso-login-callback view 에서 아래와 같은 상황에 문제가 발생할 수 있습니다.
- token이 expired 되거나
- new ara는 kaist iam 연동이 되어 있는 sparcs sso 계정으로만 사용이 가능한데도 facebook이나 twitter로 로그인하려고 하거나

위와 같은 경우에는, sparcs sso에서 준 token으로 사용자의 정보를 가져오려 할 때, sparcs sso에서 400 - 500 에러를 내려줍니다. 이에 따라, new-ara-api도 400 - 500 에러를 내려줍니다. 하지만, new-ara-web에 가기 전에 문제가 발생하는 것이라 json response로 400 - 500 에러를 내려준다고 해도 사용자는 이 에러 메시지를 제대로 확인할 수 없는 상황이었습니다.

이 PR은 아래와 같은 것들을 목표로 합니다.
- 로그인 시 문제를 겪은 사용자들에게 에러 원인을 알려줌으로써 문제를 해결할 수 있도록 도와줌.
- new-ara-sentry에 끊임없이 오고 있는 에러 메시지를 줄임.

이 PR이 적용되면 사용자는 sparcs sso 로그인 중에 문제가 발생했을 때 아래와 같은 에러 화면을 보게 됩니다.

<img width="1680" alt="스크린샷 2021-03-04 오후 10 35 03" src="https://user-images.githubusercontent.com/13573120/109971729-e3991380-7d39-11eb-815c-c41e8e8a136e.png">

이 PR의 방법이 최선은 아니며, 더 좋은 방법이 있을 것입니다. 가령 아래와 같은 종류의 해결책이 존재할 수 있습니다.

- sparcs sso에서 new-ara에 로그인 하려고 할 때, KAIST IAM 연동이 안되어 있으면 KAIST IAM 연동을 하도록 유도한다.
- sparcs sso에서 내려준 에러의 코드에 따라 new-ara-api 가 new-ara-web 의 적절한 에러 페이지로 redirection 시켜준다.

다만, 위와 같은 해결책은 적용에 시간이 오래 걸릴 것이기 때문에 좀 더 빠르게 적용할 수 있는 해결책을 일단 PR 넣어봅니다.