### PR TITLE
Optimize queryset of ArticleViewSet's recent action

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -37,6 +37,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         'partial_update': ArticleUpdateActionSerializer,
         'vote_positive': serializers.Serializer,
         'vote_negative': serializers.Serializer,
+        'recent': ArticleListActionSerializer,
     }
     permission_classes = (
         ArticlePermission,
@@ -79,6 +80,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
                 queryset = queryset.filter(
                     article_read_log_set__read_by=self.request.user,
+                ).select_related(
+                    'created_by',
+                    'created_by__profile',
                 ).annotate(
                     my_last_read_at=models.Subquery(last_read_log_of_the_article.filter(
                         read_by=self.request.user,


### PR DESCRIPTION
ArticleViewSet의 recent action의 쿼리를 최적화 했습니다.

- ArticleSerializer 대신 ArticleListActionSerializer 를 사용해 사용하는 필드만을 serialize 함.
- UserProfile을 select related로 join 해서 긁어옴.

frontend develop 브랜치에서 실행 결과 문제 없었습니다.

테스트를 위해서 CI가 작동 안하는 문제를 해결한 https://github.com/sparcs-kaist/new-ara-api/pull/185 위에 올렸습니다. 머지할 때는 분리해서 머지하겠습니다.