### PR TITLE
[#191] 신고 이메일 포맷 수정 및 어드민 페이지에 댓글 추가

### DIFF
--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from ara.classes.admin import MetaDataModelAdmin
 
 from apps.core.models import Board, Topic, Article, \
-    ArticleReadLog, ArticleDeleteLog, BestArticle, CommentDeleteLog, BestComment, FAQ, BestSearch, Report
+    ArticleReadLog, ArticleDeleteLog, BestArticle, CommentDeleteLog, BestComment, FAQ, BestSearch, Report, Comment
 
 
 @admin.register(Board)
@@ -73,6 +73,25 @@ class ArticleAdmin(MetaDataModelAdmin):
     )
     search_fields = (
         'title',
+        'content',
+    )
+
+
+@admin.register(Comment)
+class CommentAdmin(MetaDataModelAdmin):
+    list_filter = (
+        'is_anonymous',
+    )
+    list_display = (
+        'content',
+        'positive_vote_count',
+        'negative_vote_count',
+        'is_anonymous',
+        'created_by',
+        'parent_article',
+        'parent_comment',
+    )
+    search_fields = (
         'content',
     )
 

--- a/apps/core/views/viewsets/report.py
+++ b/apps/core/views/viewsets/report.py
@@ -66,7 +66,7 @@ class ReportViewSet(mixins.ListModelMixin,
                 parent_id = article_id
                 article = Article.objects.get(id=parent_id)
                 title = f"[신고 (게시글)] '{request.user.id}:: {request.user.profile}'님께서 Article {parent_id}을 신고하였습니다."
-                message =\
+                message = \
                     f'''게시글 {parent_id}에 대하여 다음과 같은 신고가 접수되었습니다:
                         신고자: {request.user.id}:: {request.user.profile}
                         신고 유형: {request.data.get('type')}
@@ -75,16 +75,17 @@ class ReportViewSet(mixins.ListModelMixin,
                         글 종류: 게시글
                         제목: {article.title}
                         작성자: {article.created_by.id}:: {article.created_by.profile}
-                        내용: {article.content}
+                        내용: {article.content_text}
                         '''
             else:
                 parent_id = request.data.get('parent_comment')
                 comment = Comment.objects.get(id=parent_id)
                 article = comment.get_parent_article()
                 title = f"[신고 (댓글)] '{request.user.id}:: {request.user.profile}'님께서 Comment {parent_id}을 신고하였습니다."
-                message =\
+                message = \
                     f'''댓글 {parent_id}에 대하여 다음과 같은 신고가 접수되었습니다:
                         신고자: {request.user.id}:: {request.user.profile}
+                        신고 유형: {request.data.get('type')}
                         신고 사유: {request.data.get('content')}
 
                         글 종류: 댓글


### PR DESCRIPTION
1. 댓글 신고할때도 이메일에 사유 들어가도록 수정
2. 신고 이메일에 html말고 내용만 오도록 
3. admin 페이지에 댓글 페이지 넣음 (신고된 댓글을 삭제해야할 경우 대비)