### PR TITLE
Optimize recent query by using aggregation

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -95,22 +95,18 @@ class BaseArticleSerializer(MetaDataModelSerializer):
 
     @staticmethod
     def get_read_status(obj) -> str:
-        if not hasattr(obj, "my_last_read_at") and not obj.article_read_log_set.exists():
+        if not obj.article_read_log_set.exists():
             return 'N'
 
-        my_article_read_time = None
-        if hasattr(obj, "my_last_read_at"):
-            my_article_read_time = obj.my_last_read_at.replace(tzinfo=timezone.get_current_timezone())
-        else:
-            my_article_read_time = obj.article_read_log_set.all()[0].created_at
+        my_article_read_log = obj.article_read_log_set.all()[0]
 
         # compare with article's last commented datetime
         if obj.commented_at:
-            if obj.commented_at > my_article_read_time:
+            if obj.commented_at > my_article_read_log.created_at:
                 return 'U'
 
         # compare with article's last updated datetime
-        if obj.content_updated_at and obj.content_updated_at > my_article_read_time:
+        if obj.content_updated_at and obj.content_updated_at > my_article_read_log.created_at:
             return 'U'
 
         return '-'

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -246,8 +246,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 ORDER BY my_last_read_at desc
                 LIMIT %s OFFSET %s
             ) recents ON recents.article_id = `core_article`.id
-            ''', [self.request.user.id, paginator.page_size, max(0, paginator.page.start_index()-1)])\
-            .prefetch_related('created_by', 'created_by__profile', 'parent_board', 'parent_topic')
+            ''', [self.request.user.id, paginator.page_size, max(0, paginator.page.start_index()-1)]) \
+            .prefetch_related('created_by', 'created_by__profile', 'parent_board', 'parent_topic') \
+            .prefetch_related(ArticleReadLog.prefetch_my_article_read_log(self.request.user))
 
         serializer = self.get_serializer_class()([v for v in queryset], many=True, context={"request": request})
         return paginator.get_paginated_response(serializer.data)

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -5,6 +5,7 @@ from django.db import models
 from rest_framework import status, viewsets, response, decorators, serializers, permissions
 
 from ara import redis
+from ara.classes.pagination import PageNumberPagination
 from ara.classes.viewset import ActionAPIViewSet
 
 from apps.core.models import (
@@ -61,8 +62,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 
-        # optimizing queryset for list action
-        if self.action in ['list', 'recent']:
+        if self.action == 'list':
+            # optimizing queryset for list action
             queryset = queryset.select_related(
                 'created_by',
                 'created_by__profile',
@@ -71,26 +72,6 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             ).prefetch_related(
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
             )
-
-            # optimizing queryset for recent action
-            if self.action == 'recent':
-                last_read_log_of_the_article = ArticleReadLog.objects.filter(
-                    article=models.OuterRef('pk')
-                ).order_by('-created_at')
-
-                queryset = queryset.filter(
-                    article_read_log_set__read_by=self.request.user,
-                ).select_related(
-                    'created_by',
-                    'created_by__profile',
-                ).annotate(
-                    my_last_read_at=models.Subquery(last_read_log_of_the_article.filter(
-                        read_by=self.request.user,
-                    ).values('created_at')[:1]),
-                ).order_by(
-                    '-my_last_read_at'
-                ).distinct()
-
         # optimizing queryset for create, update, retrieve actions
         else:
             queryset = queryset.select_related(
@@ -244,4 +225,27 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
     @decorators.action(detail=False, methods=['get'])
     def recent(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
+        # Cardinality of this queryset is same with actual query
+        count_queryset = ArticleReadLog.objects \
+            .values("article_id") \
+            .filter(read_by=request.user) \
+            .distinct()
+
+        paginator = PageNumberPagination()
+        paginator.paginate_queryset(count_queryset, request)
+
+        queryset = Article.objects.raw('''
+            SELECT * FROM `core_article`
+            JOIN (
+                SELECT `core_articlereadlog`.`article_id`, MAX(`core_articlereadlog`.`created_at`) AS my_last_read_at
+                FROM `core_articlereadlog`
+                WHERE (`core_articlereadlog`.`deleted_at` = '0001-01-01 00:00:00' AND `core_articlereadlog`.`read_by_id` = %s)
+                GROUP BY `core_articlereadlog`.`article_id`
+                ORDER BY my_last_read_at desc
+                LIMIT %s OFFSET %s
+            ) recents ON recents.article_id = `core_article`.id
+            ''', [self.request.user.id, paginator.page_size, max(0, paginator.page.start_index()-1)])\
+            .prefetch_related('created_by', 'created_by__profile')
+
+        serializer = self.get_serializer_class()([v for v in queryset], many=True, context={"request": request})
+        return paginator.get_paginated_response(serializer.data)

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -245,7 +245,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 LIMIT %s OFFSET %s
             ) recents ON recents.article_id = `core_article`.id
             ''', [self.request.user.id, paginator.page_size, max(0, paginator.page.start_index()-1)])\
-            .prefetch_related('created_by', 'created_by__profile')
+            .prefetch_related('created_by', 'created_by__profile', 'parent_board', 'parent_topic')
 
         serializer = self.get_serializer_class()([v for v in queryset], many=True, context={"request": request})
         return paginator.get_paginated_response(serializer.data)

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -3,6 +3,7 @@ import time
 from django.db import models
 
 from rest_framework import status, viewsets, response, decorators, serializers, permissions
+from rest_framework.response import Response
 
 from ara import redis
 from ara.classes.pagination import PageNumberPagination
@@ -152,7 +153,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         pipe.zadd(redis_key, {f'{article.id}:1:{self.request.user.id}:{time.time()}': time.time()})
         pipe.execute(raise_on_error=True)
 
-        return super().retrieve(request, *args, **kwargs)
+        serialized = self.serializer_class(article, context={'request': request})
+        return Response(serialized.data)
 
     @decorators.action(detail=True, methods=['post'])
     def vote_cancel(self, request, *args, **kwargs):


### PR DESCRIPTION
Recent view에서 최근 조회 일시를 가져오기 위해 서브쿼리를 사용하고 있었는데, 대신 aggregation을 사용합니다.

Django ORM으로는 temp table에 join하는 것이 어려워 raw query를 써서 아래와 같은 복잡한 점이 몇가지 생깁니다:
- `filter_queryset`에서 쿼리셋을 만들지 않고 action 함수에서 직접 만듭니다.
- 날쿼리는 paginator에서 처리할 수가 없어서 paginator를 따로 가져오고, 날쿼리에서 나온 데이터를 꽃아주는 방식으로 pagination을 구현했습니다.
- join 안하고 aggregate된 값을 바로 사용하도록 serializer를 변경했습니다.

Explain plan상으로는 확실히 빨라지는데요 (total cost 22.61 → 5.88), 아무래도 날쿼리로 인한 코드 퀄리티 저하가 좀 있는 것 같아 고민이 됩니다. 또 제 로컬에 있는 recent 테이블이 그렇게 크지 않아서 실제 성능 향상이 어느정도인지도 가늠하기 힘들고요. 프로덕션 디비를 가져와서 로드 테스팅을 해봐도 좋을 것 같습니다.
