### PR TITLE
Add anonymized user profile for anonymous posts

### DIFF
--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -1,11 +1,13 @@
 from rest_framework import serializers, exceptions
 import typing
+import hashlib
 
 from ara.classes.serializers import MetaDataModelSerializer
 
 from apps.core.models import Comment, Block
 from django.utils import timezone
 from django.utils.translation import gettext
+from ara.settings import HASH_SECRET_VALUE
 
 
 class BaseCommentSerializer(MetaDataModelSerializer):
@@ -62,7 +64,7 @@ class BaseCommentSerializer(MetaDataModelSerializer):
         from apps.user.serializers.user import PublicUserSerializer
 
         if obj.is_anonymous:
-            return gettext('anonymous')
+            return get_anonymous_user(obj)
 
         # <class 'rest_framework.utils.serializer_helpers.ReturnDict'> (is an OrderedDict)
         return PublicUserSerializer(obj.created_by).data
@@ -77,6 +79,47 @@ class BaseCommentSerializer(MetaDataModelSerializer):
 
     def get_is_hidden_by_reported(self, obj:Comment) -> bool:
         return obj.hidden_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
+
+
+def get_anonymous_user(obj) -> dict:
+    from apps.user.serializers.user import PublicUserSerializer
+    user = PublicUserSerializer(obj.created_by).data
+    # 댓글 작성자는 (작성자 id + parent article id + 시크릿)으로 구별합니다.
+    print('hash val: ', HASH_SECRET_VALUE)
+    user_num = user['id'] + obj.parent_article.id + int(HASH_SECRET_VALUE)
+    user_str = str(hex(user_num)).encode('utf-8')
+    user_hash = hashlib.sha224(user_str).hexdigest()
+    user_name = make_anonymous_name(hash(user_str))
+    user_profile_picture = make_random_profile_picture(hash(user_str))
+    return {
+        'id': user_hash,
+        'username': user_name,
+        'profile': {
+            'picture': user_profile_picture,
+            'nickname': user_name,
+            'user': user_hash
+        }
+    }
+
+
+def make_anonymous_name(hash_val) -> str:
+    nouns = ['외계인', '펭귄', '코뿔소', '여우', '염소', '타조', '사과', '포도', '다람쥐', '도토리', '해바라기', '코끼리', '돌고래', '거북이', '나비',
+             '앵무새', '알파카', '강아지', '고양이', '원숭이', '두더지', '낙타', '망아지', '시조새', '힙스터', '로봇', '감자', '고구마', '가마우지', '직박구리',
+             '오리너구리', '보노보', '개미핥기', '치타', '사자', '구렁이', '도마뱀', '개구리', '올빼미', '부엉이']
+
+    nickname = '익명의 ' + nouns[hash_val % len(nouns)]
+    return nickname
+
+
+def make_random_profile_picture(hash_val) -> str:
+    colors = ['blue', 'red', 'gray']
+    numbers = ['1', '2', '3']
+
+    temp_color = colors[hash_val % len(colors)]
+    temp_num = numbers[hash_val % len(numbers)]
+    default_picture = f'user_profiles/default_pictures/{temp_color}-default{temp_num}.png'
+
+    return default_picture
 
 
 class CommentSerializer(BaseCommentSerializer):

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -105,9 +105,9 @@ def get_anonymous_user(obj) -> dict:
     user_profile_picture = make_random_profile_picture(hash(user_unique_encoding))
 
     if parent_article_created_by_id == comment_created_by_id:
-        user_name = '글쓴이' # TODO: 번역
+        user_name = gettext('글쓴이') # TODO: 번역
     else:
-        user_name = make_anonymous_name(hash(user_unique_encoding))
+        user_name = make_anonymous_name(hash(user_unique_encoding), user_hash[-3:])
 
     return {
         'id': user_hash,
@@ -120,13 +120,12 @@ def get_anonymous_user(obj) -> dict:
     }
 
 
-def make_anonymous_name(hash_val) -> str:
+def make_anonymous_name(hash_val, unique_tail) -> str:
     nouns = ['외계인', '펭귄', '코뿔소', '여우', '염소', '타조', '사과', '포도', '다람쥐', '도토리', '해바라기', '코끼리', '돌고래', '거북이', '나비',
              '앵무새', '알파카', '강아지', '고양이', '원숭이', '두더지', '낙타', '망아지', '시조새', '힙스터', '로봇', '감자', '고구마', '가마우지', '직박구리',
-             '오리너구리', '보노보', '개미핥기', '치타', '사자', '구렁이', '도마뱀', '개구리', '올빼미', '부엉이']
+             '오리너구리', '보노보노', '개미핥기', '치타', '사자', '구렁이', '도마뱀', '개구리', '올빼미', '부엉이']
 
-    # TODO: anonymous name에서 중복 제거 (서로 다른 두 명의 댓글이 같은 이름을 가지지 않도록)
-    nickname = '익명의 ' + nouns[hash_val % len(nouns)]
+    nickname = '익명의 ' + nouns[hash_val % len(nouns)] + ' ' + unique_tail
     return nickname
 
 

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -4,7 +4,7 @@ import hashlib
 
 from ara.classes.serializers import MetaDataModelSerializer
 
-from apps.core.models import Comment, Block
+from apps.core.models import Article, Comment, Block
 from django.utils import timezone
 from django.utils.translation import gettext
 from ara.settings import HASH_SECRET_VALUE
@@ -64,6 +64,7 @@ class BaseCommentSerializer(MetaDataModelSerializer):
         from apps.user.serializers.user import PublicUserSerializer
 
         if obj.is_anonymous:
+            # TODO: 익명 게시글의 작성자가 본인의 글에 쓴 댓글은 '글쓴이'로 표시
             return get_anonymous_user(obj)
 
         # <class 'rest_framework.utils.serializer_helpers.ReturnDict'> (is an OrderedDict)
@@ -73,7 +74,7 @@ class BaseCommentSerializer(MetaDataModelSerializer):
         errors = []
 
         if Block.is_blocked(blocked_by=self.context['request'].user, user=obj.created_by):
-            errors.append(exceptions.ValidationError(gettext('This article is written by a user you blocked.')))
+            errors.append(exceptions.ValidationError(gettext('This article is written by a시 user you blocked.')))
 
         return errors
 
@@ -81,16 +82,35 @@ class BaseCommentSerializer(MetaDataModelSerializer):
         return obj.hidden_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
 
 
+def get_parent_article(obj) -> Article:
+    if obj.parent_article:
+        print('parent article writer', obj.parent_article.created_by.id)
+        return obj.parent_article
+    else:
+        parent_comment_id = obj.parent_comment.id
+        parent_article = Comment.objects.get(id=parent_comment_id).parent_article
+        return parent_article
+
+
 def get_anonymous_user(obj) -> dict:
     from apps.user.serializers.user import PublicUserSerializer
-    user = PublicUserSerializer(obj.created_by).data
-    # 댓글 작성자는 (작성자 id + parent article id + 시크릿)으로 구별합니다.
-    print('hash val: ', HASH_SECRET_VALUE)
-    user_num = user['id'] + obj.parent_article.id + int(HASH_SECRET_VALUE)
-    user_str = str(hex(user_num)).encode('utf-8')
-    user_hash = hashlib.sha224(user_str).hexdigest()
-    user_name = make_anonymous_name(hash(user_str))
-    user_profile_picture = make_random_profile_picture(hash(user_str))
+
+    parent_article = get_parent_article(obj)
+    parent_article_id = parent_article.id
+    parent_article_created_by_id = parent_article.created_by.id
+    comment_created_by_id = obj.created_by.id
+
+    # 댓글 작성자는 (작성자 id + parent article id + 시크릿)을 해시한 값으로 구별합니다.
+    user_unique_num = comment_created_by_id + parent_article_id + int(HASH_SECRET_VALUE)
+    user_unique_encoding = str(hex(user_unique_num)).encode('utf-8')
+    user_hash = hashlib.sha224(user_unique_encoding).hexdigest()
+    user_profile_picture = make_random_profile_picture(hash(user_unique_encoding))
+
+    if parent_article_created_by_id == comment_created_by_id:
+        user_name = '글쓴이' # TODO: 번역
+    else:
+        user_name = make_anonymous_name(hash(user_unique_encoding))
+
     return {
         'id': user_hash,
         'username': user_name,
@@ -107,6 +127,7 @@ def make_anonymous_name(hash_val) -> str:
              '앵무새', '알파카', '강아지', '고양이', '원숭이', '두더지', '낙타', '망아지', '시조새', '힙스터', '로봇', '감자', '고구마', '가마우지', '직박구리',
              '오리너구리', '보노보', '개미핥기', '치타', '사자', '구렁이', '도마뱀', '개구리', '올빼미', '부엉이']
 
+    # TODO: anonymous name에서 중복 제거 (서로 다른 두 명의 댓글이 같은 이름을 가지지 않도록)
     nickname = '익명의 ' + nouns[hash_val % len(nouns)]
     return nickname
 

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -64,8 +64,7 @@ class BaseCommentSerializer(MetaDataModelSerializer):
         from apps.user.serializers.user import PublicUserSerializer
 
         if obj.is_anonymous:
-            # TODO: 익명 게시글의 작성자가 본인의 글에 쓴 댓글은 '글쓴이'로 표시
-            return get_anonymous_user(obj)
+            return get_anonymous_user(obj) # 게시글 작성자의 댓글은 '글쓴이'로 표시
 
         # <class 'rest_framework.utils.serializer_helpers.ReturnDict'> (is an OrderedDict)
         return PublicUserSerializer(obj.created_by).data
@@ -93,7 +92,6 @@ def get_parent_article(obj) -> Article:
 
 
 def get_anonymous_user(obj) -> dict:
-    from apps.user.serializers.user import PublicUserSerializer
 
     parent_article = get_parent_article(obj)
     parent_article_id = parent_article.id

--- a/ara/locale/en/LC_MESSAGES/django.po
+++ b/ara/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-24 21:42+0900\n"
+"POT-Creation-Date: 2021-06-28 22:46+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,35 +22,36 @@ msgstr ""
 msgid "No content for portal article"
 msgstr ""
 
-#: apps/core/serializers/article.py:58 apps/core/serializers/article.py:69
+#: apps/core/serializers/article.py:60 apps/core/serializers/article.py:71
 msgid "This article is temporarily hidden"
 msgstr ""
 
-#: apps/core/serializers/article.py:78 apps/core/serializers/article.py:89
+#: apps/core/serializers/article.py:80 apps/core/serializers/article.py:91
 msgid "This article is hidden because it has received multiple reports"
 msgstr ""
 
-#: apps/core/serializers/article.py:100 apps/core/serializers/comment.py:65
+#: apps/core/serializers/article.py:170 apps/core/serializers/article.py:173
+#: apps/core/serializers/article.py:174
 msgid "anonymous"
 msgstr ""
 
-#: apps/core/serializers/article.py:219
+#: apps/core/serializers/article.py:247
 msgid "This article is not in user's scrap list."
 msgstr ""
 
-#: apps/core/serializers/article.py:236
+#: apps/core/serializers/article.py:264
 msgid "Wrong value for parameter 'from_view'."
 msgstr ""
 
-#: apps/core/serializers/article.py:288
+#: apps/core/serializers/article.py:316
 msgid "This article is never read by user."
 msgstr ""
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:438
 msgid "This board is read only."
 msgstr ""
 
-#: apps/core/serializers/article.py:412
+#: apps/core/serializers/article.py:440
 msgid "This board is only for KAIST members."
 msgstr ""
 
@@ -62,12 +63,16 @@ msgstr ""
 msgid "This user is already blocked."
 msgstr ""
 
-#: apps/core/serializers/comment.py:42 apps/core/serializers/comment.py:53
+#: apps/core/serializers/comment.py:44 apps/core/serializers/comment.py:55
 msgid "This comment is hidden because it received multiple reports"
 msgstr ""
 
-#: apps/core/serializers/comment.py:74
-msgid "This article is written by a user you blocked."
+#: apps/core/serializers/comment.py:76
+msgid "This article is written by a시 user you blocked."
+msgstr ""
+
+#: apps/core/serializers/comment.py:108
+msgid "글쓴이"
 msgstr ""
 
 #: apps/core/serializers/report.py:43

--- a/ara/locale/ko/LC_MESSAGES/django.po
+++ b/ara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-24 21:42+0900\n"
+"POT-Creation-Date: 2021-06-28 22:46+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,35 +22,36 @@ msgstr ""
 msgid "No content for portal article"
 msgstr "크롤링해온 포탈 게시물에 내용이 없습니다."
 
-#: apps/core/serializers/article.py:58 apps/core/serializers/article.py:69
+#: apps/core/serializers/article.py:60 apps/core/serializers/article.py:71
 msgid "This article is temporarily hidden"
 msgstr "임시 숨김 처리된 게시글입니다."
 
-#: apps/core/serializers/article.py:78 apps/core/serializers/article.py:89
+#: apps/core/serializers/article.py:80 apps/core/serializers/article.py:91
 msgid "This article is hidden because it has received multiple reports"
 msgstr "다수의 신고가 접수되어 숨김 처리된 게시글입니다."
 
-#: apps/core/serializers/article.py:100 apps/core/serializers/comment.py:65
+#: apps/core/serializers/article.py:170 apps/core/serializers/article.py:173
+#: apps/core/serializers/article.py:174
 msgid "anonymous"
 msgstr "익명"
 
-#: apps/core/serializers/article.py:219
+#: apps/core/serializers/article.py:247
 msgid "This article is not in user's scrap list."
 msgstr "사용자가 스크랩하지 않은 글입니다."
 
-#: apps/core/serializers/article.py:236
+#: apps/core/serializers/article.py:264
 msgid "Wrong value for parameter 'from_view'."
 msgstr "from_view 쿼리 파라미터 value값이 틀렸습니다."
 
-#: apps/core/serializers/article.py:288
+#: apps/core/serializers/article.py:316
 msgid "This article is never read by user."
 msgstr "읽은적이 없는 게시물입니다."
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:438
 msgid "This board is read only."
 msgstr "읽기 전용 게시판입니다."
 
-#: apps/core/serializers/article.py:412
+#: apps/core/serializers/article.py:440
 msgid "This board is only for KAIST members."
 msgstr "카이스트 구성원만 이용할 수 있는 게시판입니다."
 
@@ -62,13 +63,19 @@ msgstr "스스로를 차단할 수 없습니다."
 msgid "This user is already blocked."
 msgstr "이미 차단된 사용자입니다."
 
-#: apps/core/serializers/comment.py:42 apps/core/serializers/comment.py:53
+#: apps/core/serializers/comment.py:44 apps/core/serializers/comment.py:55
 msgid "This comment is hidden because it received multiple reports"
 msgstr "다수의 신고가 접수되어 숨김 처리된 댓글 입니다."
 
-#: apps/core/serializers/comment.py:74
-msgid "This article is written by a user you blocked."
+#: apps/core/serializers/comment.py:76
+#, fuzzy
+#| msgid "This article is written by a user you blocked."
+msgid "This article is written by a시 user you blocked."
 msgstr "차단한 사용자의 게시물입니다."
+
+#: apps/core/serializers/comment.py:108
+msgid "글쓴이"
+msgstr "writer"
 
 #: apps/core/serializers/report.py:43
 msgid "You already reported this article."

--- a/ara/settings/django.py
+++ b/ara/settings/django.py
@@ -109,6 +109,7 @@ USE_L10N = True
 USE_TZ = True
 
 SECRET_KEY = env('SECRET_KEY')
+HASH_SECRET_VALUE = env('HASH_SECRET_VALUE')
 
 DATABASES = {
     'default': {

--- a/ara/settings/env.py
+++ b/ara/settings/env.py
@@ -15,4 +15,5 @@ env = environ.Env(
     SSO_SECRET_KEY=(str, os_environ.get('SSO_SECRET_KEY')),
     PORTAL_ID=(str, os_environ.get('PORTAL_ID')),
     PORTAL_PASSWORD=(str, os_environ.get('PORTAL_PASSWORD')),
+    HASH_SECRET_VALUE=(int, os_environ.get('HASH_SECRET_VALUE', 1234)),
 )


### PR DESCRIPTION
API response 익명화 로직입니다.

커밋 b098c3b Make comment json response anonymous 부터 봐주시면 감사하겠습니다. (이전 커밋은 그 전에 따온 Feature/issue 190/auto delete over reported 브랜치의 것입니다.)

익명 article의 get request가 들어오면, 글쓴이를 식별 가능한 정보(user id, 닉네임등)를 빼고, 닉네임 "익명"과  랜덤한 프로필 이미지를 넣어서 보냅니다.

익명 comment의 get request가 들어오면, 마찬가지로 글쓴이 식별 가능한 정보 (user id, 닉네임 등)을 빼고, `user id + article id + secret key`를 해싱한 값을 사용하여 '익명의 개구리 1ab'와 같은 닉네임 + 랜덤 프로필 이미지로 리턴합니다. 
물론, 같은 사용자가 한 게시글 내에 여러 개의 댓글을 달 경우 닉네임과 프로필 이미지는 다 같습니다. 
또한, 게시글의 글쓴이가 본인의 글에 단 댓글은 '글쓴이'로 표시됩니다.
