### PR TITLE
article, comment serializer에 is_mine 추가

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -39,6 +39,9 @@ class BaseArticleSerializer(MetaDataModelSerializer):
 
         return BaseScrapSerializer(my_scrap).data
 
+    def get_is_mine(self, obj) -> bool:
+        return self.context['request'].user == obj.created_by
+
     def get_is_hidden(self, obj) -> bool:
         if self.validate_hidden(obj):
             return True
@@ -304,6 +307,9 @@ class ArticleSerializer(BaseArticleSerializer):
         source='comment_set',
     )
 
+    is_mine = serializers.SerializerMethodField(
+        read_only=True,
+    )
     is_hidden = serializers.SerializerMethodField(
         read_only=True,
     )

--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -20,6 +20,9 @@ class BaseCommentSerializer(MetaDataModelSerializer):
 
         return my_vote.is_positive
 
+    def get_is_mine(self, obj) -> bool:
+        return self.context['request'].user == obj.created_by
+
     def get_is_hidden(self, obj) -> bool:
         if self.validate_hidden(obj):
             return True
@@ -76,6 +79,9 @@ class CommentSerializer(BaseCommentSerializer):
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )
+    is_mine = serializers.SerializerMethodField(
+        read_only=True,
+    )
     is_hidden = serializers.SerializerMethodField(
         read_only=True,
     )
@@ -99,6 +105,9 @@ class CommentListActionSerializer(BaseCommentSerializer):
         read_only=True,
     )
     my_vote = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    is_mine = serializers.SerializerMethodField(
         read_only=True,
     )
     is_hidden = serializers.SerializerMethodField(


### PR DESCRIPTION
< 7/5 회의시간 논의 >
익명글/댓글의 경우 id를 해싱해서 내려주게 되면서 프론트에서 이 글/댓글이 본인글인지 확인이 불가능해짐.
그래서 is_mine 필드를 serializer에 넣어서 함께 내려줌.

이 필드를 통해 프론트는 유저가 이 글/댓글을 수정/삭제 할 수 있는지 판단할 수 있음.
is_mine은 boolean 으로 내려갑니다. (true/false)