### PR TITLE
Fix side-article filter condition from created_at to id

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -240,8 +240,8 @@ class ArticleSerializer(BaseArticleSerializer):
                 articles = self.search_articles(articles, request.query_params.get('search_query'))
 
             articles = articles.exclude(id=obj.id)
-            before = articles.filter(created_at__lte=obj.created_at).first()
-            after = articles.filter(created_at__gte=obj.created_at).last()
+            before = articles.filter(id__lt=obj.id).first()
+            after = articles.filter(id__gt=obj.id).last()
 
         return {
             'before': SideArticleSerializer(before, context=self.context).data if before else None,


### PR DESCRIPTION
이슈 [#212 ]에 적은 내용입니다:

정확히 같은 시간에 작성된 글들 사이에 side_articles에서 무한 루프 버그가 발생합니다.

### 문제
같은 시간에 작성된 A, B 게시글에 대해, A의 before & after가 B가 되며, B의 before & after가 A가 됩니다.
예시: https://newara.sparcs.org/post/231012?from_view=board

자세한 상황은 노션 카드 참고: https://www.notion.so/sparcs/side_articles-1ec72349d9be4734ae601a929211f510

### 기존 코드 (`serializers/article.py` , get_side_articles)
```python
before = articles.filter(created_at__lte=obj.created_at).first()
after = articles.filter(created_at__gte=obj.created_at).last()
```

기존 코드의 문제점:
- created_at__lte, created_at__gte 둘다 equality가 포함됨. 그래서 정확하게 같은 시간에 2개의 글 A & B가 올라올 경우, A의 before & after article이 둘다 B가 됨. (B의 before & after article도 둘다 A가 됨)
- lte, gte를 lte, gt로 바꿔준다고 해도, 순서가 게시판 순서와 달라짐.
    - ex) A = B < C 순서로 글이 올라왔을때,
        - (A의 이전글: B, 이후글: C) , (B의 이전글: A, 이후글: C )가 됨.
        - 이렇게 되면 안되고, A의 이전글: null, 이후글: C가 되어야함.

### 해결 방법
시간 순으로 정렬할 경우, 2개의 글이 동시에 올라운 경우 순서를 정의할 수 없음. 게시판 순서를 그대로 표현하기 위해 id 순으로 정렬후, id_lt, id_gt로 수정했습니다.