### PR TITLE
다른 사용자의 게시글 목록을 조회할 때, 익명 게시글 제외

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -63,11 +63,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
         if self.action == 'list':
             created_by = self.request.query_params.get('created_by')
-            if created_by is not None:  # 특정 사용자의 글을 가져오는 쿼리
-                created_by = int(created_by)
-                if created_by != self.request.user.id:  # 사용자가 다른 사람의 글들을 가져올 때 (ex. 사용자 이름 클릭해서)
-                    # 다른 사용자의 글들을 볼때는, 익명 글 숨기기
-                    queryset = queryset.exclude(is_anonymous=1)
+            if created_by and int(created_by) != self.request.user.id:
+                queryset = queryset.exclude(is_anonymous=True)
 
             # optimizing queryset for list action
             queryset = queryset.select_related(

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -62,8 +62,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         queryset = super().filter_queryset(queryset)
 
         if self.action == 'list':
-            created_by = int(self.request.query_params.get('created_by'))
+            created_by = self.request.query_params.get('created_by')
             if created_by is not None:  # 특정 사용자의 글을 가져오는 쿼리
+                created_by = int(created_by)
                 if created_by != self.request.user.id:  # 사용자가 다른 사람의 글들을 가져올 때 (ex. 사용자 이름 클릭해서)
                     # 다른 사용자의 글들을 볼때는, 익명 글 숨기기
                     queryset = queryset.exclude(is_anonymous=1)

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -62,6 +62,12 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         queryset = super().filter_queryset(queryset)
 
         if self.action == 'list':
+            created_by = int(self.request.query_params.get('created_by'))
+            if created_by is not None:  # 특정 사용자의 글을 가져오는 쿼리
+                if created_by != self.request.user.id:  # 사용자가 다른 사람의 글들을 가져올 때 (ex. 사용자 이름 클릭해서)
+                    # 다른 사용자의 글들을 볼때는, 익명 글 숨기기
+                    queryset = queryset.exclude(is_anonymous=1)
+
             # optimizing queryset for list action
             queryset = queryset.select_related(
                 'created_by',
@@ -71,6 +77,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             ).prefetch_related(
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
             )
+
         # optimizing queryset for create, update, retrieve actions
         else:
             queryset = queryset.select_related(


### PR DESCRIPTION
마이페이지에서 내가 쓴 글을 볼때, 그리고 게시글에서 작성자 이름을 클릭해서 그 작성자의 모든 글을 볼때 아래 api를 사용합니다:
api/articles/?created_by=1

다른 사용자의 글 목록을 조회할 때는 익명 게시글이 보이지 않고, 자신의 작성 글 목록에는 자신이 작성한 익명 게시글들이 보이도록 수정하였습니다.