### PR TITLE
Fix search on recents and scraps

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -235,8 +235,9 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             if id_set:
                 search_restriction_sql = 'AND `core_articlereadlog`.`article_id` IN (' + ', '.join(map(str, id_set)) + ') '
             else:
-                # there is no search result! In this edge case, 'IN ()' cause a mysql error
-                search_restriction_sql = 'AND FALSE'
+                # There is no search result! Return empty result
+                self.paginate_queryset(ArticleReadLog.objects.none())
+                return self.paginator.get_paginated_response([])
 
         # Cardinality of this queryset is same with actual query
         count_queryset = ArticleReadLog.objects \

--- a/apps/core/views/viewsets/scrap.py
+++ b/apps/core/views/viewsets/scrap.py
@@ -13,6 +13,8 @@ from apps.core.serializers.scrap import (
     ScrapCreateActionSerializer,
 )
 
+from apps.core.documents import ArticleDocument
+
 
 class ScrapViewSet(mixins.ListModelMixin,
                    mixins.CreateModelMixin,
@@ -31,8 +33,16 @@ class ScrapViewSet(mixins.ListModelMixin,
         queryset = super(ScrapViewSet, self).get_queryset()
 
         queryset = queryset.filter(
-            scrapped_by=self.request.user,
-        ).select_related(
+            scrapped_by=self.request.user
+        )
+
+        search_keyword = self.request.query_params.get('main_search__contains')
+        if search_keyword:
+            queryset = queryset.filter(
+                id__in=ArticleDocument.get_main_search_id_set(search_keyword)
+            )
+        
+        queryset = queryset.select_related(
             'scrapped_by',
             'scrapped_by__profile',
             'parent_article',


### PR DESCRIPTION
- Fixed search on scraps
  - 새로운 filterset을 만들기보다, 어차피 scrap의 경우 이미 scrapped_by로 queryset이 filter되고 있는 만큼 거기에 같이 얹어가도록 구현했습니다. 
- Fixed search on recents
  - es에서 얻어온 id_set을 이용해 subquery 단에서부터 미리 글을 거를 수 있도록 구현했습니다. 
  - `search_restriction_sql`을 str.join 등을 이용해 직접 만들고 있는데, 이렇게 하는 것이 최선일지 의견 남겨 주시면 감사하겠습니다.