### PR TITLE
익명 게시글 프사 링크 제대로 안들어가는 문제 해결

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 
 import bs4
+from django.core.files.storage import default_storage
 
 from django.db import models, IntegrityError, transaction
 from django.conf import settings
@@ -204,7 +205,7 @@ class Article(MetaDataModel):
                 'id': 0,
                 'username': gettext('anonymous'),
                 'profile': {
-                    'picture': user_profile_picture,
+                    'picture': default_storage.url(user_profile_picture),
                     'nickname': gettext('anonymous'),
                     'user': gettext('anonymous')
                 },

--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 import hashlib
 
+from django.core.files.storage import default_storage
 from django.db import models, IntegrityError
 from django.conf import settings
 from django.utils import timezone
@@ -163,7 +164,7 @@ class Comment(MetaDataModel):
                 'id': user_hash,
                 'username': user_name,
                 'profile': {
-                    'picture': user_profile_picture,
+                    'picture': default_storage.url(user_profile_picture),
                     'nickname': user_name,
                     'user': user_hash
                 }

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -75,7 +75,7 @@ def set_anonymous_article(request):
         title='익명글',
         is_content_sexual=False,
         is_content_social=False,
-        is_anonymous=False,
+        is_anonymous=True,
         content='example content',
         content_text='example content text',
         created_by=request.cls.user2,
@@ -201,17 +201,15 @@ class TestAnonymousUser(TestCase, RequestSetting):
     def test_anonymous_article_profile_picture(self):
         r = self.http_request(self.user, 'get', f'articles/{self.article_anonymous.id}').data
         profile_picture_url = r.get('created_by')['profile']['picture']
-        validate = URLValidator
         try:
-            validate(profile_picture_url)
+            URLValidator(profile_picture_url)
         except ValidationError:
             assert False, 'Bad URL for anonymous article profile picture'
 
     def test_anonymous_comment_profile_picture(self):
         r = self.http_request(self.user, 'get', f'comments/{self.comment_anonymous.id}').data
         profile_picture_url = r.get('created_by')['profile']['picture']
-        validate = URLValidator
         try:
-            validate(profile_picture_url)
+            URLValidator(profile_picture_url)
         except ValidationError:
             assert False, 'Bad URL for anonymous comment profile picture'


### PR DESCRIPTION
익명 글/댓글에 대한 프로필 사진의 경우, PublicUserProfileSerializer를 거치지 않아 프로필 사진 링크가 미완성이었습니다.
따라서 익명 글/댓글의 프로필 사진 링크를 완성하였습니다.

<img width="338" alt="Screen Shot 2021-08-07 at 11 06 38 AM" src="https://user-images.githubusercontent.com/48045424/128584610-dabae907-746f-41b0-9fdb-a70fb2c42b22.png">
