### PR TITLE
익명 게시글에 hashed user id 추가 

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext
 
-from apps.user.views.viewsets import make_random_profile_picture
+from apps.user.views.viewsets import make_random_profile_picture, hashlib
 from ara.db.models import MetaDataModel
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
@@ -198,10 +198,12 @@ class Article(MetaDataModel):
         else:
             user_unique_num = self.created_by.id + self.id + HASH_SECRET_VALUE
             user_unique_encoding = str(hex(user_unique_num)).encode('utf-8')
-            user_profile_picture = make_random_profile_picture(hash(user_unique_encoding))
+            user_hash = hashlib.sha224(user_unique_encoding).hexdigest()
+            user_hash_int = int(user_hash[-4:], 16)
+            user_profile_picture = make_random_profile_picture(user_hash_int)
 
             return {
-                'id': 0,
+                'id': user_hash,
                 'username': gettext('anonymous'),
                 'profile': {
                     'picture': user_profile_picture,


### PR DESCRIPTION
기존엔 익명 게시글에 hashed user id를 넣지 않았으나, 필요하게 되어 hashed user id를 추가합니다.