### PR TITLE
scrap의 side_articles 문제 해결

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -239,13 +239,14 @@ class ArticleSerializer(BaseArticleSerializer):
             if request.query_params.get('search_query'):
                 articles = self.search_articles(articles, request.query_params.get('search_query'))
 
+            articles = articles.exclude(id=obj.id)
+
             if from_view == 'scrap':
-                articles = articles.exclude(id=obj.id)
-                before = articles.filter(scrap_set__created_at__lte=obj.scrap_set.get().created_at).first()
-                after = articles.filter(scrap_set__created_at__gte=obj.scrap_set.get().created_at).last()
+                scrap_obj_created_at = obj.scrap_set.get().created_at
+                before = articles.filter(scrap_set__created_at__lte=scrap_obj_created_at).first()
+                after = articles.filter(scrap_set__created_at__gte=scrap_obj_created_at).last()
                 
             else:
-                articles = articles.exclude(id=obj.id)
                 before = articles.filter(created_at__lte=obj.created_at).first()
                 after = articles.filter(created_at__gte=obj.created_at).last()
 

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -239,9 +239,15 @@ class ArticleSerializer(BaseArticleSerializer):
             if request.query_params.get('search_query'):
                 articles = self.search_articles(articles, request.query_params.get('search_query'))
 
-            articles = articles.exclude(id=obj.id)
-            before = articles.filter(created_at__lte=obj.created_at).first()
-            after = articles.filter(created_at__gte=obj.created_at).last()
+            if from_view == 'scrap':
+                articles = articles.exclude(id=obj.id)
+                before = articles.filter(scrap_set__created_at__lte=obj.scrap_set.get().created_at).first()
+                after = articles.filter(scrap_set__created_at__gte=obj.scrap_set.get().created_at).last()
+                
+            else:
+                articles = articles.exclude(id=obj.id)
+                before = articles.filter(created_at__lte=obj.created_at).first()
+                after = articles.filter(created_at__gte=obj.created_at).last()
 
         return {
             'before': SideArticleSerializer(before, context=self.context).data if before else None,

--- a/tests/test_scrap.py
+++ b/tests/test_scrap.py
@@ -156,3 +156,11 @@ class TestScrap(TestCase, RequestSetting):
         res2 = self.http_request(self.user, 'get', f'articles/{self.article.id}', querystring = 'from_view=scrap')
         assert res2.data['side_articles']['before']['id'] == self.article2.id
 
+    def test_scrapped_by_multiple_user(self):
+        # 한 게시글이 여러명에게 스크랩될 때, side_article 순서가 잘 작동하는지 확인
+        Scrap.objects.create(parent_article=self.article, scrapped_by=self.user)
+        Scrap.objects.create(parent_article=self.article2, scrapped_by=self.user)
+        Scrap.objects.create(parent_article=self.article2, scrapped_by=self.user2) # 같은 글을 user2가 스크랩
+
+        res1 = self.http_request(self.user, 'get', f'articles/{self.article.id}', querystring = 'from_view=scrap')
+        assert res1.data['side_articles']['after']['id'] == self.article2.id

--- a/tests/test_scrap.py
+++ b/tests/test_scrap.py
@@ -144,3 +144,15 @@ class TestScrap(TestCase, RequestSetting):
         scrap = self.http_request(self.user2, 'get', 'scraps').data
         assert scrap.get('num_items') == 1
         assert scrap.get('results')[0].get('parent_article').get('is_hidden')
+
+    def test_scrap_side_article_order(self):
+        # side_article 순서가 게시글 작성 순서가 아닌 스크랩 순서인지 확인
+        Scrap.objects.create(parent_article=self.article2, scrapped_by=self.user) # 늦게 작성, 먼저 스크랩 된 글 
+        Scrap.objects.create(parent_article=self.article, scrapped_by=self.user) # 먼저 작성, 늦게 스크랩 된 글
+
+        res1 = self.http_request(self.user, 'get', f'articles/{self.article2.id}', querystring = 'from_view=scrap')
+        assert res1.data['side_articles']['after']['id'] == self.article.id
+
+        res2 = self.http_request(self.user, 'get', f'articles/{self.article.id}', querystring = 'from_view=scrap')
+        assert res2.data['side_articles']['before']['id'] == self.article2.id
+


### PR DESCRIPTION
issue #228
fromview=scrap 에서 보이는 side_article의 after,before를 결정짓는 순서가 article table의 created_at으로 되어있던 것을 scrap table의 created_at을 참조하도록 변경하였습니다.

테스트코드 작성하였습니다.