### PR TITLE
Admin page의 게시글, 댓글 페이지에서 username으로 search하는 기능 추가

### DIFF
--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -111,6 +111,7 @@ class ArticleAdmin(MetaDataModelAdmin):
         'title',
         'content',
         'hidden_at',
+        'created_by__username',
     )
     actions = ('restore_hidden_articles',)
 
@@ -142,6 +143,7 @@ class CommentAdmin(MetaDataModelAdmin):
     search_fields = (
         'content',
         'hidden_at',
+        'created_by__username',
     )
     actions = ('restore_hidden_comments',)
 

--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -111,7 +111,7 @@ class ArticleAdmin(MetaDataModelAdmin):
         'title',
         'content',
         'hidden_at',
-        'created_by__username',
+        'created_by__email'
     )
     actions = ('restore_hidden_articles',)
 
@@ -143,7 +143,7 @@ class CommentAdmin(MetaDataModelAdmin):
     search_fields = (
         'content',
         'hidden_at',
-        'created_by__username',
+        'created_by__email'
     )
     actions = ('restore_hidden_comments',)
 


### PR DESCRIPTION
특정 id로 작성된 모든 article/comment를 삭제해달라는 문의가 자주 들어옵니다.
지금은 각 article을 제목으로 찾아 일일히 삭제해야해서 번거롭습니다.
그래서 search field에 user id를 추가하고자 합니다.