### PR TITLE
Unified hidden messages for articles

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = venv/*

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 	pytest tests/
 
 test_coverage:
-	pytest --cov=. tests/
+	pytest --cov-report html --cov=. --cov-config=.coveragerc tests/
 
 test_coverage_missing:
 	pytest --cov-report term-missing --cov=. tests/

--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, Union
 
 import bs4
@@ -15,6 +16,14 @@ from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
 from .report import Report
 from .comment import Comment
+
+
+class ArticleHiddenReason(Enum):
+    ADULT_CONTENT = 'ADULT_CONTENT'
+    SOCIAL_CONTENT = 'SOCIAL_CONTENT'
+    REPORTED_CONTENT = 'REPORTED_CONTENT'
+    BLOCKED_USER_CONTENT = 'BLOCKED_USER_CONTENT'
+    ACCESS_DENIED_CONTENT = 'ACCESS_DENIED_CONTENT'
 
 
 class Article(MetaDataModel):

--- a/apps/core/permissions/article.py
+++ b/apps/core/permissions/article.py
@@ -11,6 +11,7 @@ class ArticlePermission(permissions.IsAuthenticated):
         return super().has_object_permission(request, view, obj)
 
 
+# TODO: Rename to ArticleGroupPermission
 class ArticleKAISTPermission(permissions.BasePermission):
     message = 'KAIST 구성원만 읽을 수 있는 게시물입니다.'
 

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -125,6 +125,7 @@ class BaseArticleSerializer(MetaDataModelSerializer):
             reasons.append(ArticleHiddenReason.ADULT_CONTENT)
         if obj.is_content_social and not request.user.profile.see_social:
             reasons.append(ArticleHiddenReason.SOCIAL_CONTENT)
+        # 혹시 몰라 여기 두기는 하는데 여기 오기전에 Permission에서 막혀야 함
         if not obj.parent_board.group_has_access(request.user.profile.group):
             reasons.append(ArticleHiddenReason.ACCESS_DENIED_CONTENT)
         if obj.is_hidden_by_reported():

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -1,9 +1,8 @@
 import typing
-from functools import cached_property
 
 from django.db import models
 from django.utils.translation import gettext
-from rest_framework import exceptions, serializers
+from rest_framework import serializers
 
 from apps.core.documents import ArticleDocument
 from apps.core.models import Article, ArticleReadLog, Board, Block, Scrap, ArticleHiddenReason

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -145,6 +145,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         article = self.get_object()
+        override_hidden = 'override_hidden' in self.request.query_params
 
         ArticleReadLog.objects.create(
             read_by=self.request.user,
@@ -158,7 +159,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         pipe.zadd(redis_key, {f'{article.id}:1:{self.request.user.id}:{time.time()}': time.time()})
         pipe.execute(raise_on_error=True)
 
-        serialized = ArticleSerializer(article, context={'request': request})
+        serialized = ArticleSerializer(article, context={'request': request, 'override_hidden': override_hidden})
         return Response(serialized.data)
 
     @decorators.action(detail=True, methods=['post'])

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -158,7 +158,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         pipe.zadd(redis_key, {f'{article.id}:1:{self.request.user.id}:{time.time()}': time.time()})
         pipe.execute(raise_on_error=True)
 
-        serialized = self.serializer_class(article, context={'request': request})
+        serialized = ArticleSerializer(article, context={'request': request})
         return Response(serialized.data)
 
     @decorators.action(detail=True, methods=['post'])

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -401,7 +401,8 @@ class TestHiddenArticles(TestCase, RequestSetting):
             UserProfile.objects.get_or_create(**{
                 **profile_kwargs,
                 'user': user_instance,
-                'agree_terms_of_service_at': timezone.now()
+                'agree_terms_of_service_at': timezone.now(),
+                'group': UserProfile.UserGroup.KAIST_MEMBER
             })
         return user_instance
 
@@ -487,6 +488,7 @@ class TestHiddenArticles(TestCase, RequestSetting):
         )
 
         res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert 'SOCIAL_CONTENT' in res.get('why_hidden')
         assert res.get('is_content_social')
         assert res.get('can_override_hidden')
         assert res.get('is_hidden')
@@ -494,7 +496,6 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert res.get('content') is None
         assert res.get('hidden_title') is None
         assert res.get('hidden_content') is None
-        assert 'SOCIAL_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.clean_mind_user, target_article, True)
 
     def test_social_article_pass(self):
@@ -504,8 +505,8 @@ class TestHiddenArticles(TestCase, RequestSetting):
         )
 
         res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
-        assert res.get('is_content_social')
         assert res.get('can_override_hidden') is None
+        assert res.get('is_content_social')
         assert not res.get('is_hidden')
         assert res.get('title') is not None
         assert res.get('content') is not None

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -471,7 +471,7 @@ class TestHiddenArticles(TestCase, RequestSetting):
             is_content_social=False
         )
 
-        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        res = self.http_request(self.dirty_mind_user, 'get', f'articles/{target_article.id}').data
         assert res.get('is_content_sexual')
         assert res.get('can_override_hidden') is None
         assert not res.get('is_hidden')
@@ -504,7 +504,7 @@ class TestHiddenArticles(TestCase, RequestSetting):
             is_content_social=True
         )
 
-        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        res = self.http_request(self.dirty_mind_user, 'get', f'articles/{target_article.id}').data
         assert res.get('can_override_hidden') is None
         assert res.get('is_content_social')
         assert not res.get('is_hidden')

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -330,7 +330,6 @@ class TestArticle(TestCase, RequestSetting):
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 0
 
-    # TODO: TestHiddenArticles suite랑 겹치니까 게시물 읽기 부분은 삭제
     @pytest.mark.usefixtures('set_kaist_articles')
     def test_kaist_permission(self):
         # 카이스트 구성원만 볼 수 있는 게시판에 대한 테스트
@@ -551,15 +550,3 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert res.get('hidden_content') is None
         assert 'REPORTED_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.clean_mind_user, target_article, False)
-
-    @pytest.mark.usefixtures('set_kaist_articles')
-    def test_access_denied_block(self):
-        res = self.http_request(self.non_kaist_user, 'get', f'articles/{self.kaist_article.id}')
-        assert not res.get('can_override_hidden')
-        assert res.get('is_hidden')
-        assert res.get('title') is None
-        assert res.get('content') is None
-        assert res.get('hidden_title') is None
-        assert res.get('hidden_content') is None
-        assert 'ACCESS_DENIED_CONTENT' in res.get('why_hidden')
-        self._test_can_override(self.clean_mind_user, self.kaist_article, False)

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from apps.core.models import Article, Topic, Board
+from apps.core.models import Article, Topic, Board, Block
 from apps.user.models import UserProfile
 from tests.conftest import RequestSetting, TestCase
 
@@ -330,6 +330,7 @@ class TestArticle(TestCase, RequestSetting):
         assert article.positive_vote_count == 0
         assert article.negative_vote_count == 0
 
+    # TODO: TestHiddenArticles suite랑 겹치니까 게시물 읽기 부분은 삭제
     @pytest.mark.usefixtures('set_kaist_articles')
     def test_kaist_permission(self):
         # 카이스트 구성원만 볼 수 있는 게시판에 대한 테스트
@@ -389,3 +390,224 @@ class TestArticle(TestCase, RequestSetting):
 
         res2 = self.http_request(self.user2, 'get', 'articles')
         assert res2.data['results'][0]['read_status'] == 'U'
+
+
+@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_topic', 'set_article')
+class TestHiddenArticles(TestCase, RequestSetting):
+    @staticmethod
+    def _user_factory(user_kwargs, profile_kwargs):
+        user_instance, _ = User.objects.get_or_create(**user_kwargs)
+        if not hasattr(user_instance, 'profile'):
+            UserProfile.objects.get_or_create(**{
+                **profile_kwargs,
+                'user': user_instance,
+                'agree_terms_of_service_at': timezone.now()
+            })
+        return user_instance
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.clean_mind_user = cls._user_factory(
+            {'username': 'clean-mind-user', 'email': 'iamclean@sparcs.org'},
+            {'nickname': 'clean', 'see_social': False, 'see_sexual': False}
+        )
+        cls.dirty_mind_user = cls._user_factory(
+            {'username': 'dirty-mind-user', 'email': 'kbdwarrior@sparcs.org'},
+            {'nickname': 'kbdwarrior', 'see_social': True, 'see_sexual': True}
+        )
+
+    def _test_can_override(self, user: User, target_article: Article, expected: bool):
+        res = self.http_request(user, 'get', f'articles/{target_article.id}', None, 'override_hidden').data
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert res.get('why_hidden') is not None
+        assert res.get('why_hidden') != []
+        assert res.get('is_hidden') != expected
+        if expected:
+            assert res.get('title') is not None
+            assert res.get('content') is not None
+        else:
+            assert res.get('title') is None
+            assert res.get('content') is None
+
+    def test_sexual_article_block(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=True,
+            is_content_social=False,
+            hit_count=0,
+            positive_vote_count=0,
+            negative_vote_count=0,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('is_content_sexual')
+        assert res.get('can_override_hidden')
+        assert res.get('is_hidden')
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert res.get('title') is None
+        assert res.get('content') is None
+        assert 'ADULT_CONTENT' in res.get('why_hidden')
+        self._test_can_override(self.clean_mind_user, target_article, True)
+
+    def test_sexual_article_pass(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=True,
+            is_content_social=False,
+            hit_count=0,
+            positive_vote_count=0,
+            negative_vote_count=0,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('is_content_sexual')
+        assert res.get('can_override_hidden') is None
+        assert not res.get('is_hidden')
+        assert res.get('title') is not None
+        assert res.get('content') is not None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert res.get('why_hidden') == []
+
+    def test_social_article_block(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=False,
+            is_content_social=True,
+            hit_count=0,
+            positive_vote_count=0,
+            negative_vote_count=0,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('is_content_social')
+        assert res.get('can_override_hidden')
+        assert res.get('is_hidden')
+        assert res.get('title') is None
+        assert res.get('content') is None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert 'SOCIAL_CONTENT' in res.get('why_hidden')
+        self._test_can_override(self.clean_mind_user, target_article, True)
+
+    def test_sexual_article_pass(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=False,
+            is_content_social=True,
+            hit_count=0,
+            positive_vote_count=0,
+            negative_vote_count=0,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('is_content_social')
+        assert res.get('can_override_hidden') is None
+        assert not res.get('is_hidden')
+        assert res.get('title') is not None
+        assert res.get('content') is not None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert res.get('why_hidden') == []
+
+    def test_blocked_user_block(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=False,
+            is_content_social=True,
+            hit_count=0,
+            positive_vote_count=0,
+            negative_vote_count=0,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+        Block.objects.create(
+            blocked_by=self.clean_mind_user,
+            user=self.user
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('can_override_hidden')
+        assert res.get('is_hidden')
+        assert res.get('title') is None
+        assert res.get('content') is None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert 'BLOCKED_USER_CONTENT' in res.get('why_hidden')
+        self._test_can_override(self.clean_mind_user, target_article, True)
+
+    def test_reported_article_block(self):
+        target_article = Article.objects.create(
+            title="example article",
+            content="example content",
+            content_text="example content text",
+            is_anonymous=False,
+            is_content_sexual=False,
+            is_content_social=True,
+            hit_count=0,
+            positive_vote_count=10000,
+            negative_vote_count=0,
+            report_count=1000000,
+            created_by=self.user,
+            parent_topic=self.topic,
+            parent_board=self.board,
+            commented_at=timezone.now()
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert not res.get('can_override_hidden')
+        assert res.get('is_hidden')
+        assert res.get('title') is None
+        assert res.get('content') is None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert 'REPORTED_CONTENT' in res.get('why_hidden')
+        self._test_can_override(self.clean_mind_user, target_article, False)
+
+    @pytest.mark.usefixtures('set_kaist_articles')
+    def test_access_denied_block(self):
+        res = self.http_request(self.non_kaist_user, 'get', f'articles/{self.kaist_article.id}')
+        assert not res.get('can_override_hidden')
+        assert res.get('is_hidden')
+        assert res.get('title') is None
+        assert res.get('content') is None
+        assert res.get('hidden_title') is None
+        assert res.get('hidden_content') is None
+        assert 'ACCESS_DENIED_CONTENT' in res.get('why_hidden')
+        self._test_can_override(self.clean_mind_user, self.kaist_article, False)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -160,8 +160,8 @@ class TestReport(TestCase, RequestSetting):
         res2 = self.http_request(self.user, 'get', f'articles/{self.article.id}').data
         assert res2.get('title') != self.article.title
         assert res2.get('content') != self.article.content
-        assert '숨김' in res2.get('title')
-        assert '숨김' in res2.get('content')
+        assert res2.get('title') is None
+        assert res2.get('content') is None
 
     # 한 댓글이 여러번 신고당하면 자동 숨김되는 것 확인
     def test_hide_comment_if_many_reports(self):


### PR DESCRIPTION
게시물이 숨겨졌을 때에 대한 API를 보다 일관되게 정리합니다. ([Notion Ticket](https://www.notion.so/sparcs/2693dc9cd9fd48ffbcfb82e8523b3823))
모두 GET `/articles/:id`에 대한 수정사항입니다.
# 주요 수정사항
- `hidden_title`, `hidden_content` 필드 삭제 (참고: 숨겨진 상태일 경우 `title`, `content` 모두 null)
- `string[]` 타입의 `why_hidden` 필드를 추가하여 숨겨진 이유들에 대한 목록을 반환 (값은 하단 참고)
- 숨겨진 내용을 보고자 할 때에는 query에 `override_hidden` 키를 주면 됨
- 솜겨진 내용을 볼 수 있는지 (cf. 신고로 숨겨진 글은 숨기기를 풀 수 없음) 여부는 `can_override_hidden` 값을 반환
  애초에 숨겨지지 않았던 게시물은 `can_override_hidden`이 null임.

참고) 숨겨진 글을 보더라도 why_hidden은 유지되기 때문에 원래부터 볼 수 있는 글인지, override한 글인지 응답 내용으로 구분이 가능

# why_hidden 값
- `ADULT_CONTENT`
- `SOCIAL_CONTENT`
- `REPORETED_CONTENT`
- `BLOCKED_USER_CONTENT`

논의되었던 ACCESS_DENIED_CONTENT의 경우 Serializer에 도달하기 전 Permission에서 403 요청을 보내고 끝내버리기 때문에 굳이 추가될 필요가 없었습니다 (=프런트 팀에서 고려하지 않아도 됨)

미래에 추가로 권한 관리가 들어갈 수 있는 가능성을 고려해 ACCESS_DENIED_CONTENT를 뱉는 코드를 **삭제하지는 않았습니다** (`BaseArticleSerializer.hidden_info` 참고)