### PR TITLE
Feature/unify hidden message of comment

### DIFF
--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, Union
 import hashlib
 
@@ -14,6 +15,12 @@ from ara.db.models import MetaDataModel, MetaDataQuerySet
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
 from .report import Report
+
+
+class CommentHiddenReason(Enum):
+    REPORTED_CONTENT = 'REPORTED_CONTENT'
+    BLOCKED_USER_CONTENT = 'BLOCKED_USER_CONTENT'
+    DELETED_CONTENT = 'DELETED_CONTENT'
 
 
 class Comment(MetaDataModel):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -185,5 +185,5 @@ class TestReport(TestCase, RequestSetting):
         # 신고가 threshold 이상인 경우 읽을 수 없음 (현재 총 3번 신고됨, 현재 threshold 1)
         res2 = self.http_request(self.user, 'get', f'comments/{self.comment.id}').data
         assert res2.get('content') != self.comment.content
-        assert '숨김' in res2.get('content')
+        assert res2.get('content') is None
 


### PR DESCRIPTION
정훈님의 #247 이슈에 대해 comment에서도 동일한 로직으로 hidden message를 통합했습니다.
자세한 설명은 #252를 참고해주세요.

전체적인 로직은 #247과 모두 같으며, 한가지 차이점만 존재합니다.
#247에서는 ArticleViewset에서 retrieve함수안에서  request 쿼리에 override_hidden이 있는지 확인하고 serializer의 context에 request와 별개로 인자를 넣어주지만,
댓글에 대해서는 BaseCommentSerializer의 requested_override_hidden()에서 쿼리에 직접 override_hidden이 있는지 확인합니다.
```
    @property
    def requested_override_hidden(self):
        request = self.context['request']
        override_hidden = 'override_hidden' in request.query_params
        return override_hidden
```