### PR TITLE
Prevent modification of hidden/deleted articles and comments

### DIFF
--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, Union
 import hashlib
 
@@ -14,6 +15,12 @@ from ara.db.models import MetaDataModel, MetaDataQuerySet
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
 from .report import Report
+
+
+class CommentHiddenReason(Enum):
+    REPORTED_CONTENT = 'REPORTED_CONTENT'
+    BLOCKED_USER_CONTENT = 'BLOCKED_USER_CONTENT'
+    DELETED_CONTENT = 'DELETED_CONTENT'
 
 
 class Comment(MetaDataModel):

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -121,6 +121,13 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
             created_by=self.request.user,
         )
 
+    def update(self, request, *args, **kwargs):
+        article = self.get_object()
+        if article.is_hidden_by_reported():
+            return response.Response({'message': 'Cannot modify articles hidden by reports'},
+                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return super().update(request, *args, **kwargs)
+
     def perform_update(self, serializer):
         instance = serializer.instance
 

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -1,6 +1,7 @@
 import time
 
 from django.db import models
+from django.utils.translation import gettext
 from rest_framework import status, viewsets, response, decorators, serializers, permissions
 from rest_framework.response import Response
 
@@ -124,8 +125,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def update(self, request, *args, **kwargs):
         article = self.get_object()
         if article.is_hidden_by_reported():
-            return response.Response({'message': 'Cannot modify articles hidden by reports'},
-                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return response.Response({'message': gettext('Cannot modify articles hidden by reports')},
+                                     status=status.HTTP_403_FORBIDDEN)
         return super().update(request, *args, **kwargs)
 
     def perform_update(self, serializer):

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext
 from rest_framework import mixins, status, response, decorators, serializers, permissions
 
 from ara.classes.viewset import ActionAPIViewSet
@@ -58,8 +59,8 @@ class CommentViewSet(mixins.CreateModelMixin,
         comment = self.get_object()
 
         if comment.is_hidden_by_reported() or comment.is_deleted():
-            return response.Response({'message': 'Cannot modify hidden or deleted comments'},
-                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return response.Response({'message': gettext('Cannot modify hidden or deleted comments')},
+                                     status=status.HTTP_403_FORBIDDEN)
 
         return super().update(request, *args, **kwargs)
 

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -54,6 +54,15 @@ class CommentViewSet(mixins.CreateModelMixin,
             created_by=self.request.user,
         )
 
+    def update(self, request, *args, **kwargs):
+        comment = self.get_object()
+
+        if comment.is_hidden_by_reported() or comment.is_deleted():
+            return response.Response({'message': 'Cannot modify hidden or deleted comments'},
+                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        return super().update(request, *args, **kwargs)
+
     def perform_update(self, serializer):
         from apps.core.models import CommentUpdateLog
 

--- a/ara/locale/en/LC_MESSAGES/django.po
+++ b/ara/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 21:09+0900\n"
+"POT-Creation-Date: 2021-10-04 19:08+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,40 +34,32 @@ msgstr ""
 msgid "No content for portal article"
 msgstr ""
 
-#: apps/core/models/article.py:208 apps/core/models/article.py:211
-#: apps/core/models/article.py:212
+#: apps/core/models/article.py:217 apps/core/models/article.py:220
+#: apps/core/models/article.py:221
 msgid "anonymous"
 msgstr ""
 
-#: apps/core/models/comment.py:162
+#: apps/core/models/comment.py:171
 msgid "author"
 msgstr ""
 
-#: apps/core/serializers/article.py:63 apps/core/serializers/article.py:74
-msgid "This article is temporarily hidden"
-msgstr ""
-
-#: apps/core/serializers/article.py:82 apps/core/serializers/article.py:93
-msgid "This article is hidden because it has received multiple reports"
-msgstr ""
-
-#: apps/core/serializers/article.py:214
+#: apps/core/serializers/article.py:201
 msgid "This article is not in user's scrap list."
 msgstr ""
 
-#: apps/core/serializers/article.py:231
+#: apps/core/serializers/article.py:218
 msgid "Wrong value for parameter 'from_view'."
 msgstr ""
 
-#: apps/core/serializers/article.py:283
+#: apps/core/serializers/article.py:291
 msgid "This article is never read by user."
 msgstr ""
 
-#: apps/core/serializers/article.py:408
+#: apps/core/serializers/article.py:410
 msgid "This board is read only."
 msgstr ""
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:412
 msgid "This board is only for KAIST members."
 msgstr ""
 
@@ -79,24 +71,20 @@ msgstr ""
 msgid "This user is already blocked."
 msgstr ""
 
-#: apps/core/serializers/comment.py:46 apps/core/serializers/comment.py:60
-msgid "This comment is deleted"
-msgstr ""
-
-#: apps/core/serializers/comment.py:49 apps/core/serializers/comment.py:63
-msgid "This comment is hidden because it received multiple reports"
-msgstr ""
-
-#: apps/core/serializers/comment.py:81
-msgid "This article is written by a user you blocked."
-msgstr ""
-
 #: apps/core/serializers/report.py:43
 msgid "You already reported this article."
 msgstr ""
 
 #: apps/core/serializers/scrap.py:37
 msgid "This article is already scrapped."
+msgstr ""
+
+#: apps/core/views/viewsets/article.py:128
+msgid "Cannot modify articles hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/comment.py:62
+msgid "Cannot modify hidden or deleted comments"
 msgstr ""
 
 #: apps/user/models/user_profile.py:23

--- a/ara/locale/ko/LC_MESSAGES/django.po
+++ b/ara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 21:09+0900\n"
+"POT-Creation-Date: 2021-10-04 19:08+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,40 +34,32 @@ msgstr "(선택된) 숨겨진 댓글 목록을 복구합니다."
 msgid "No content for portal article"
 msgstr ""
 
-#: apps/core/models/article.py:208 apps/core/models/article.py:211
-#: apps/core/models/article.py:212
+#: apps/core/models/article.py:217 apps/core/models/article.py:220
+#: apps/core/models/article.py:221
 msgid "anonymous"
 msgstr "익명"
 
-#: apps/core/models/comment.py:162
+#: apps/core/models/comment.py:171
 msgid "author"
 msgstr "글쓴이"
 
-#: apps/core/serializers/article.py:63 apps/core/serializers/article.py:74
-msgid "This article is temporarily hidden"
-msgstr "임시 숨김 처리된 게시글입니다."
-
-#: apps/core/serializers/article.py:82 apps/core/serializers/article.py:93
-msgid "This article is hidden because it has received multiple reports"
-msgstr "다수의 신고가 접수되어 숨김 처리된 게시글입니다."
-
-#: apps/core/serializers/article.py:214
+#: apps/core/serializers/article.py:201
 msgid "This article is not in user's scrap list."
 msgstr "사용자가 스크랩하지 않은 글입니다."
 
-#: apps/core/serializers/article.py:231
+#: apps/core/serializers/article.py:218
 msgid "Wrong value for parameter 'from_view'."
 msgstr "from_view 쿼리 파라미터 value값이 틀렸습니다."
 
-#: apps/core/serializers/article.py:283
+#: apps/core/serializers/article.py:291
 msgid "This article is never read by user."
 msgstr "읽은적이 없는 게시물입니다."
 
-#: apps/core/serializers/article.py:408
+#: apps/core/serializers/article.py:410
 msgid "This board is read only."
 msgstr "읽기 전용 게시판입니다."
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:412
 msgid "This board is only for KAIST members."
 msgstr "카이스트 구성원만 이용할 수 있는 게시판입니다."
 
@@ -79,18 +71,6 @@ msgstr "스스로를 차단할 수 없습니다."
 msgid "This user is already blocked."
 msgstr "이미 차단된 사용자입니다."
 
-#: apps/core/serializers/comment.py:46 apps/core/serializers/comment.py:60
-msgid "This comment is deleted"
-msgstr "삭제된 댓글입니다."
-
-#: apps/core/serializers/comment.py:49 apps/core/serializers/comment.py:63
-msgid "This comment is hidden because it received multiple reports"
-msgstr "다수의 신고가 접수되어 숨김 처리된 게시글입니다."
-
-#: apps/core/serializers/comment.py:81
-msgid "This article is written by a user you blocked."
-msgstr "차단한 사용자의 게시물입니다."
-
 #: apps/core/serializers/report.py:43
 msgid "You already reported this article."
 msgstr "이미 신고한 글입니다."
@@ -98,6 +78,14 @@ msgstr "이미 신고한 글입니다."
 #: apps/core/serializers/scrap.py:37
 msgid "This article is already scrapped."
 msgstr "이미 스크랩한 게시글입니다."
+
+#: apps/core/views/viewsets/article.py:128
+msgid "Cannot modify articles hidden by reports"
+msgstr "다수의 신고로 숨겨진 게시글은 수정할 수 없습니다."
+
+#: apps/core/views/viewsets/comment.py:62
+msgid "Cannot modify hidden or deleted comments"
+msgstr "삭제되거나 다수의 신고로 숨겨진 댓글은 수정할 수 없습니다."
 
 #: apps/user/models/user_profile.py:23
 msgid "Unauthorized user"
@@ -128,3 +116,18 @@ msgstr "한국어"
 #: ara/settings/django.py:97
 msgid "English"
 msgstr "영어"
+
+#~ msgid "This article is temporarily hidden"
+#~ msgstr "임시 숨김 처리된 게시글입니다."
+
+#~ msgid "This article is hidden because it has received multiple reports"
+#~ msgstr "다수의 신고가 접수되어 숨김 처리된 게시글입니다."
+
+#~ msgid "This comment is deleted"
+#~ msgstr "삭제된 댓글입니다."
+
+#~ msgid "This comment is hidden because it received multiple reports"
+#~ msgstr "다수의 신고가 접수되어 숨김 처리된 게시글입니다."
+
+#~ msgid "This article is written by a user you blocked."
+#~ msgstr "차단한 사용자의 게시물입니다."

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -583,4 +583,4 @@ class TestHiddenArticles(TestCase, RequestSetting):
             "content_text": new_content,
         })
 
-        assert res.status_code == 405
+        assert res.status_code == 403

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -550,3 +550,37 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert res.get('hidden_content') is None
         assert 'REPORTED_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.clean_mind_user, target_article, False)
+
+    def test_modify_deleted_article(self):
+        target_article = self._article_factory(
+            is_content_sexual=False,
+            is_content_social=False,
+        )
+
+        self.http_request(self.user, 'delete', f'articles/{target_article.id}')
+
+        new_content = "attempt to modify deleted article"
+        res = self.http_request(self.user, 'put', f'articles/{target_article.id}', {
+            "title": new_content,
+            "content": new_content,
+            "content_text": new_content,
+        })
+
+        assert res.status_code == 404
+
+    def test_modify_report_hidden_article(self):
+        target_article = self._article_factory(
+            is_content_sexual=False,
+            is_content_social=False,
+            report_count=1000000,
+            hidden_at=timezone.now()
+        )
+
+        new_content = "attempt to modify hidden article"
+        res = self.http_request(self.user, 'put', f'articles/{target_article.id}', {
+            "title": new_content,
+            "content": new_content,
+            "content_text": new_content,
+        })
+
+        assert res.status_code == 405

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -381,3 +381,25 @@ class TestHiddenComments(TestCase, RequestSetting):
         assert res.get('hidden_content') is None
         assert 'DELETED_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.user, target_comment, False)
+
+    def test_modify_deleted_comment(self):
+        target_comment = self._comment_factory(
+            deleted_at=timezone.now()
+        )
+
+        res = self.http_request(self.user, 'patch', f'comments/{target_comment.id}', {
+            'content': 'attempt to modify deleted comment',
+        })
+
+        assert res.status_code == 405
+
+    def test_modify_report_hidden_article(self):
+        target_comment = self._comment_factory(
+            report_count=1000000,
+            hidden_at=timezone.now()
+        )
+
+        res = self.http_request(self.user, 'patch', f'comments/{target_comment.id}', {
+            'content': 'attempt to modify hidden comment'
+        })
+        assert res.status_code == 405

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -391,7 +391,7 @@ class TestHiddenComments(TestCase, RequestSetting):
             'content': 'attempt to modify deleted comment',
         })
 
-        assert res.status_code == 405
+        assert res.status_code == 403
 
     def test_modify_report_hidden_article(self):
         target_comment = self._comment_factory(
@@ -402,4 +402,4 @@ class TestHiddenComments(TestCase, RequestSetting):
         res = self.http_request(self.user, 'patch', f'comments/{target_comment.id}', {
             'content': 'attempt to modify hidden comment'
         })
-        assert res.status_code == 405
+        assert res.status_code == 403

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -185,5 +185,5 @@ class TestReport(TestCase, RequestSetting):
         # 신고가 threshold 이상인 경우 읽을 수 없음 (현재 총 3번 신고됨, 현재 threshold 1)
         res2 = self.http_request(self.user, 'get', f'comments/{self.comment.id}').data
         assert res2.get('content') != self.comment.content
-        assert '숨김' in res2.get('content')
+        assert res2.get('content') is None
 


### PR DESCRIPTION
삭제되거나 신고에 의해 숨겨진 게시글/댓글에 대한 수정 요청을 거부합니다.

이슈 #253 에 설명된 작업을 구현하였습니다.
테스트 케이스 작성을 위해 water님께서 PR #254 에서 작업하신 내용이 필요하여, merge하였습니다.

### 수정내용
게시글:
- 삭제된 게시글에 대한 POST 요청:
    - 기존 로직으로도 update() 중 get_object()에서 404가 뜨며, 처리되지 않습니다. (로직 수정 필요없음)
- 신고로 숨겨진 게시글에 대한 POST 요청:
    - viewsets/article.py에서 update()를 overriding 하여, `is_hidden_by_reported()`일 경우 HTTP 405를 리턴합니다.

댓글:
- 게시글과의 차이점:
    - 사용자에게 `삭제된 게시글입니다`를 보여주기 위해 DB에서 댓글을 삭제하지 않도록 구현되어 있습니다. 따라서, 삭제된 게시글에 대해 404가 뜨지 않습니다.
- 삭제 / 신고 숨김된 게시글에 대한 POST 요청:
    - viewsets/comment.py에서 update()를 overriding 하여, `is_deleted() or is_hidden_by_reported()`일 경우 HTTP 405를 리턴합니다. 