### PR TITLE
Add hidden-related columns to BestArticleListActionSerializer

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -389,6 +389,15 @@ class BestArticleListActionSerializer(BaseArticleSerializer):
     created_by = serializers.SerializerMethodField(
         read_only=True,
     )
+    is_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    why_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    can_override_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )
 
 
 class ArticleCreateActionSerializer(BaseArticleSerializer):


### PR DESCRIPTION
HomeView에서 오늘의 인기글 / 금주의 인기글에서 hidden 관련 필드가 없어서 추가합니다.
여기서 사용하는 BestArticleListActionSerializer에 필드 property가 없어서 문제였습니다.

HomeView 자체에 테스트가 없어서 (see #259) 한번에 짜려고 테스트는 안짰습니다.
Fixes #260 