### PR TITLE
Refactor hidden object logic

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -1,7 +1,8 @@
+import bs4
+import typing
 from enum import Enum
 from typing import Dict, Union
 
-import bs4
 from django.core.files.storage import default_storage
 
 from django.db import models, IntegrityError, transaction
@@ -14,6 +15,7 @@ from apps.user.views.viewsets import make_random_profile_picture, hashlib
 from ara.db.models import MetaDataModel
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
+from .block import Block
 from .report import Report
 from .comment import Comment
 
@@ -222,3 +224,19 @@ class Article(MetaDataModel):
                 },
             }
 
+    # @cache_by_user
+    def hidden_reasons(self, user: settings.AUTH_USER_MODEL) -> typing.List:
+        reasons = []
+        if Block.is_blocked(blocked_by=user, user=self.created_by):
+            reasons.append(ArticleHiddenReason.BLOCKED_USER_CONTENT)
+        if self.is_content_sexual and not user.profile.see_sexual:
+            reasons.append(ArticleHiddenReason.ADULT_CONTENT)
+        if self.is_content_social and not user.profile.see_social:
+            reasons.append(ArticleHiddenReason.SOCIAL_CONTENT)
+        # 혹시 몰라 여기 두기는 하는데 여기 오기전에 Permission에서 막혀야 함
+        if not self.parent_board.group_has_access(user.profile.group):
+            reasons.append(ArticleHiddenReason.ACCESS_DENIED_CONTENT)
+        if self.is_hidden_by_reported():
+            reasons.append(ArticleHiddenReason.REPORTED_CONTENT)
+
+        return reasons

--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -12,6 +12,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext
 
 from apps.user.views.viewsets import make_random_profile_picture, hashlib
+from ara.classes.decorator import cache_by_user
 from ara.db.models import MetaDataModel
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
@@ -224,7 +225,7 @@ class Article(MetaDataModel):
                 },
             }
 
-    # @cache_by_user
+    @cache_by_user
     def hidden_reasons(self, user: settings.AUTH_USER_MODEL) -> typing.List:
         reasons = []
         if Block.is_blocked(blocked_by=user, user=self.created_by):

--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -12,6 +12,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext
 
 from apps.user.views.viewsets import NOUNS, make_random_profile_picture
+from ara.classes.decorator import cache_by_user
 from ara.db.models import MetaDataModel, MetaDataQuerySet
 from ara.sanitizer import sanitize
 from ara.settings import HASH_SECRET_VALUE
@@ -184,6 +185,7 @@ class Comment(MetaDataModel):
                 }
             }
 
+    @cache_by_user
     def hidden_reasons(self, user: settings.AUTH_USER_MODEL) -> typing.List:
         reasons: typing.List[CommentHiddenReason] = []
 

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -7,19 +7,21 @@ from rest_framework import serializers
 from apps.core.documents import ArticleDocument
 from apps.core.models import Article, ArticleReadLog, Board, Block, Scrap, ArticleHiddenReason
 from apps.core.serializers.board import BoardSerializer
+from apps.core.serializers.mixins.hidden import HiddenSerializerMixin, HiddenSerializerFieldMixin
 from apps.core.serializers.topic import TopicSerializer
 from apps.user.serializers.user import PublicUserSerializer
 from ara.classes.serializers import MetaDataModelSerializer
 
 
-CAN_OVERRIDE_REASONS = [
-    ArticleHiddenReason.SOCIAL_CONTENT,
-    ArticleHiddenReason.ADULT_CONTENT,
-    ArticleHiddenReason.BLOCKED_USER_CONTENT
-]
+class BaseArticleSerializer(HiddenSerializerMixin, MetaDataModelSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.CAN_OVERRIDE_REASONS = [
+            ArticleHiddenReason.SOCIAL_CONTENT,
+            ArticleHiddenReason.ADULT_CONTENT,
+            ArticleHiddenReason.BLOCKED_USER_CONTENT
+        ]
 
-
-class BaseArticleSerializer(MetaDataModelSerializer):
     class Meta:
         model = Article
         exclude = ('content', 'content_text', 'attachments',
@@ -44,22 +46,6 @@ class BaseArticleSerializer(MetaDataModelSerializer):
         my_scrap = obj.scrap_set.all()[0]
 
         return BaseScrapSerializer(my_scrap).data
-
-    def get_is_mine(self, obj) -> bool:
-        return self.context['request'].user == obj.created_by
-
-    def get_is_hidden(self, obj) -> bool:
-        return not self.visible_verdict(obj)
-
-    def get_why_hidden(self, obj) -> typing.List[str]:
-        _, _, reasons = self.hidden_info(obj)
-        return [reason.value for reason in reasons]
-
-    def get_can_override_hidden(self, obj) -> typing.Optional[bool]:
-        hidden, can_override, _ = self.hidden_info(obj)
-        if not hidden:
-            return
-        return can_override
 
     def get_title(self, obj) -> typing.Optional[str]:
         if self.visible_verdict(obj):
@@ -107,51 +93,14 @@ class BaseArticleSerializer(MetaDataModelSerializer):
             )
 
             return queryset.count() // view.paginator.page_size + 1
-
         return None
 
-    def visible_verdict(self, obj):
-        hidden, can_override, _ = self.hidden_info(obj)
-        return not hidden or (can_override and self.requested_override_hidden)
 
-    @property
-    def requested_override_hidden(self):
-        return 'override_hidden' in self.context and self.context['override_hidden'] is True
-
-    # TODO: 전체 캐싱 (여기에 이 메소드 자체가 없도록 디자인을 바꿔야할듯)
-    def hidden_info(self, obj) -> typing.Tuple[bool, bool, typing.List[ArticleHiddenReason]]:
-        reasons: typing.List[ArticleHiddenReason] = []
-        request = self.context['request']
-
-        if Block.is_blocked(blocked_by=request.user, user=obj.created_by):
-            reasons.append(ArticleHiddenReason.BLOCKED_USER_CONTENT)
-        if obj.is_content_sexual and not request.user.profile.see_sexual:
-            reasons.append(ArticleHiddenReason.ADULT_CONTENT)
-        if obj.is_content_social and not request.user.profile.see_social:
-            reasons.append(ArticleHiddenReason.SOCIAL_CONTENT)
-        # 혹시 몰라 여기 두기는 하는데 여기 오기전에 Permission에서 막혀야 함
-        if not obj.parent_board.group_has_access(request.user.profile.group):
-            reasons.append(ArticleHiddenReason.ACCESS_DENIED_CONTENT)
-        if obj.is_hidden_by_reported():
-            reasons.append(ArticleHiddenReason.REPORTED_CONTENT)
-
-        cannot_override_reasons = [reason for reason in reasons if reason not in CAN_OVERRIDE_REASONS]
-        can_override = len(cannot_override_reasons) == 0
-
-        return len(reasons) > 0, can_override, reasons
-
-
-class SideArticleSerializer(BaseArticleSerializer):
+class SideArticleSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     class Meta(BaseArticleSerializer.Meta):
         pass
 
     created_by = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    is_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    why_hidden = serializers.SerializerMethodField(
         read_only=True,
     )
     can_override_hidden = serializers.SerializerMethodField(
@@ -165,7 +114,7 @@ class SideArticleSerializer(BaseArticleSerializer):
     )
 
 
-class ArticleSerializer(BaseArticleSerializer):
+class ArticleSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     class Meta(BaseArticleSerializer.Meta):
         exclude = ('migrated_hit_count', 'migrated_positive_vote_count', 'migrated_negative_vote_count', 'content_text',)
 
@@ -326,15 +275,6 @@ class ArticleSerializer(BaseArticleSerializer):
     is_mine = serializers.SerializerMethodField(
         read_only=True,
     )
-    is_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    why_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    can_override_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
     title = serializers.SerializerMethodField(
         read_only=True,
     )
@@ -358,17 +298,11 @@ class ArticleSerializer(BaseArticleSerializer):
     )
 
 
-class ArticleListActionSerializer(BaseArticleSerializer):
+class ArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     parent_topic = TopicSerializer(
         read_only=True,
     )
     parent_board = BoardSerializer(
-        read_only=True,
-    )
-    is_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    why_hidden = serializers.SerializerMethodField(
         read_only=True,
     )
     title = serializers.SerializerMethodField(
@@ -382,20 +316,11 @@ class ArticleListActionSerializer(BaseArticleSerializer):
     )
 
 
-class BestArticleListActionSerializer(BaseArticleSerializer):
+class BestArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     title = serializers.SerializerMethodField(
         read_only=True,
     )
     created_by = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    is_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    why_hidden = serializers.SerializerMethodField(
-        read_only=True,
-    )
-    can_override_hidden = serializers.SerializerMethodField(
         read_only=True,
     )
 

--- a/apps/core/serializers/mixins/hidden.py
+++ b/apps/core/serializers/mixins/hidden.py
@@ -1,0 +1,49 @@
+import typing
+from rest_framework import serializers
+
+
+class HiddenSerializerMixin(metaclass=serializers.SerializerMetaclass):
+    CAN_OVERRIDE_REASONS = []
+
+    def get_is_mine(self, obj) -> bool:
+        return self.context['request'].user == obj.created_by
+
+    def get_is_hidden(self, obj) -> bool:
+        return not self.visible_verdict(obj)
+
+    def get_why_hidden(self, obj) -> typing.List[str]:
+        _, _, reasons = self.hidden_info(obj)
+        return [reason.value for reason in reasons]
+
+    def get_can_override_hidden(self, obj) -> typing.Optional[bool]:
+        hidden, can_override, _ = self.hidden_info(obj)
+        if not hidden:
+            return
+        return can_override
+
+    def visible_verdict(self, obj):
+        hidden, can_override, _ = self.hidden_info(obj)
+        return not hidden or (can_override and self.requested_override_hidden)
+
+    @property
+    def requested_override_hidden(self):
+        return 'override_hidden' in self.context and self.context['override_hidden'] is True
+
+    def hidden_info(self, obj) -> typing.Tuple[bool, bool, typing.List]:
+        user = self.context['request'].user
+        reasons = obj.hidden_reasons(user)
+        cannot_override_reasons = [reason for reason in reasons if reason not in self.CAN_OVERRIDE_REASONS]
+        can_override = len(cannot_override_reasons) == 0
+        return len(reasons) > 0, can_override, reasons
+
+
+class HiddenSerializerFieldMixin(metaclass=serializers.SerializerMetaclass):
+    is_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    why_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )
+    can_override_hidden = serializers.SerializerMethodField(
+        read_only=True,
+    )

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -55,6 +55,13 @@ class CommentViewSet(mixins.CreateModelMixin,
             created_by=self.request.user,
         )
 
+    def retrieve(self, request, *args, **kwargs):
+        comment = self.get_object()
+        override_hidden = 'override_hidden' in self.request.query_params
+
+        serialized = CommentSerializer(comment, context={'request': request, 'override_hidden': override_hidden})
+        return response.Response(serialized.data)
+
     def update(self, request, *args, **kwargs):
         comment = self.get_object()
 

--- a/ara/classes/decorator.py
+++ b/ara/classes/decorator.py
@@ -1,0 +1,16 @@
+OVERRIDE_KEY = 'ignore_cache'
+
+
+def cache_by_user(func):
+    def wrapper(*args, **kwargs):
+        instance = args[0]
+        user = args[1]
+        ignore_cache = OVERRIDE_KEY in kwargs and kwargs[OVERRIDE_KEY] is True
+
+        cache_key = f'USER_CACHE-{func.__name__}-{user.id}'
+        if cache_key not in instance.__dict__ or ignore_cache:
+            instance.__dict__[cache_key] = func(*args, **kwargs)
+        return instance.__dict__[cache_key]
+
+    return wrapper
+


### PR DESCRIPTION
Article과 Comment의 숨김 관련 로직에 대한 리팩토링입니다.
Article, Comment에서 사용하는 필드와 숨김 관련 로직이 동일하기 때문에 `HiddenSerializerMixin`로 로직을 빼서 중복을 없앱니다.
또한 모델별로 달라지는 숨김 이유 판단은 모델의 method로 옮겨 Active Record에 맞게 로직의 위치를 수정합니다.

동일한 객체에 대해 hidden_reason을 여러번 연산하는 것을 막기 위해 `@cache_by_user` 데코레이터를 작성, 적용하였습니다. `@cached_property`와 같이 인스턴스별로 캐시되는데, 사용자 누구에 대한 것인지에 대한 것도 키에 넣어서 캐싱한다고 보시면 됩니다.