### PR TITLE
Prevent vote/report/comments on deleted/hidden articles/comments

### DIFF
--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -104,7 +104,6 @@ class CommentViewSet(mixins.CreateModelMixin,
         return super().perform_update(serializer)
 
     def destroy(self, request, *args, **kwargs):
-        print('enter destroy comment')
         comment = self.get_object()
 
         if comment.is_hidden_by_reported() or comment.is_deleted():

--- a/ara/locale/en/LC_MESSAGES/django.po
+++ b/ara/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-04 19:08+0900\n"
+"POT-Creation-Date: 2021-10-04 23:18+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,11 +55,11 @@ msgstr ""
 msgid "This article is never read by user."
 msgstr ""
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:419
 msgid "This board is read only."
 msgstr ""
 
-#: apps/core/serializers/article.py:412
+#: apps/core/serializers/article.py:421
 msgid "This board is only for KAIST members."
 msgstr ""
 
@@ -83,8 +83,52 @@ msgstr ""
 msgid "Cannot modify articles hidden by reports"
 msgstr ""
 
+#: apps/core/views/viewsets/article.py:149
+msgid "Cannot delete articles hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/article.py:185
+msgid "Cannot cancel vote on articles hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/article.py:215
+#: apps/core/views/viewsets/article.py:244
+msgid "Cannot vote on your own article"
+msgstr ""
+
+#: apps/core/views/viewsets/article.py:219
+#: apps/core/views/viewsets/article.py:248
+msgid "Cannot vote on articles hidden by reports"
+msgstr ""
+
 #: apps/core/views/viewsets/comment.py:62
 msgid "Cannot modify hidden or deleted comments"
+msgstr ""
+
+#: apps/core/views/viewsets/comment.py:84
+msgid "Cannot delete hidden or deleted comments"
+msgstr ""
+
+#: apps/core/views/viewsets/comment.py:102
+msgid "Cannot cancel vote on comments that are deleted or hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/comment.py:119
+#: apps/core/views/viewsets/comment.py:143
+msgid "Cannot vote on your own comment"
+msgstr ""
+
+#: apps/core/views/viewsets/comment.py:123
+#: apps/core/views/viewsets/comment.py:147
+msgid "Cannot vote on comments that are deleted or hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/report.py:69
+msgid "Cannot report articles that are deleted or hidden by reports"
+msgstr ""
+
+#: apps/core/views/viewsets/report.py:74
+msgid "Cannot report comments that are deleted or hidden by reports"
 msgstr ""
 
 #: apps/user/models/user_profile.py:23

--- a/ara/locale/ko/LC_MESSAGES/django.po
+++ b/ara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-04 19:08+0900\n"
+"POT-Creation-Date: 2021-10-04 23:18+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,11 +55,11 @@ msgstr "from_view 쿼리 파라미터 value값이 틀렸습니다."
 msgid "This article is never read by user."
 msgstr "읽은적이 없는 게시물입니다."
 
-#: apps/core/serializers/article.py:410
+#: apps/core/serializers/article.py:419
 msgid "This board is read only."
 msgstr "읽기 전용 게시판입니다."
 
-#: apps/core/serializers/article.py:412
+#: apps/core/serializers/article.py:421
 msgid "This board is only for KAIST members."
 msgstr "카이스트 구성원만 이용할 수 있는 게시판입니다."
 
@@ -83,9 +83,69 @@ msgstr "이미 스크랩한 게시글입니다."
 msgid "Cannot modify articles hidden by reports"
 msgstr "다수의 신고로 숨겨진 게시글은 수정할 수 없습니다."
 
+#: apps/core/views/viewsets/article.py:149
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot delete articles hidden by reports"
+msgstr "다수의 신고로 숨겨진 게시글은 삭제할 수 없습니다."
+
+#: apps/core/views/viewsets/article.py:185
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot cancel vote on articles hidden by reports"
+msgstr "다수의 신고로 숨겨진 게시글에 대한 좋아요/싫어요는 취소할 수 없습니다."
+
+#: apps/core/views/viewsets/article.py:215
+#: apps/core/views/viewsets/article.py:244
+msgid "Cannot vote on your own article"
+msgstr "본인의 글에 좋아요/싫어요를 할 수 없습니다."
+
+#: apps/core/views/viewsets/article.py:219
+#: apps/core/views/viewsets/article.py:248
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot vote on articles hidden by reports"
+msgstr "다수의 신고로 숨겨진 게시글은 좋아요/싫어요 할 수 없습니다."
+
 #: apps/core/views/viewsets/comment.py:62
 msgid "Cannot modify hidden or deleted comments"
 msgstr "삭제되거나 다수의 신고로 숨겨진 댓글은 수정할 수 없습니다."
+
+#: apps/core/views/viewsets/comment.py:84
+#, fuzzy
+#| msgid "Cannot modify hidden or deleted comments"
+msgid "Cannot delete hidden or deleted comments"
+msgstr "삭제되거나 다수의 신고로 숨겨진 댓글은 삭제할 수 없습니다."
+
+#: apps/core/views/viewsets/comment.py:102
+msgid "Cannot cancel vote on comments that are deleted or hidden by reports"
+msgstr "삭제되거나 다수의 신고로 숨겨진 댓글에 대한 좋아요/싫어요를 취소할 수 없습니다."
+
+#: apps/core/views/viewsets/comment.py:119
+#: apps/core/views/viewsets/comment.py:143
+#, fuzzy
+#| msgid "Cannot modify hidden or deleted comments"
+msgid "Cannot vote on your own comment"
+msgstr "본인의 댓글에 좋아요/싫어요 할 수 없습니다."
+
+#: apps/core/views/viewsets/comment.py:123
+#: apps/core/views/viewsets/comment.py:147
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot vote on comments that are deleted or hidden by reports"
+msgstr "삭제되거나 다수의 신고로 숨겨진 댓글은 좋아요/싫어요 할 수 없습니다."
+
+#: apps/core/views/viewsets/report.py:69
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot report articles that are deleted or hidden by reports"
+msgstr "삭제되거나 다수의 신고로 숨겨진 게시글은 신고할 수 없습니다."
+
+#: apps/core/views/viewsets/report.py:74
+#, fuzzy
+#| msgid "Cannot modify articles hidden by reports"
+msgid "Cannot report comments that are deleted or hidden by reports"
+msgstr "삭제되거나 다수의 신고로 숨겨진 댓글은 신고할 수 없습니다."
 
 #: apps/user/models/user_profile.py:23
 msgid "Unauthorized user"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,10 @@ def set_user_client2(request):
 @pytest.fixture(scope='class')
 def set_user_client3(request):
     request.cls.user3, _ = User.objects.get_or_create(username='User3', email='user3@sparcs.org')
+    if not hasattr(request.cls.user3, 'profile'):
+        UserProfile.objects.get_or_create(user=request.cls.user3, nickname='User3',
+                                          group=UserProfile.UserGroup.KAIST_MEMBER, agree_terms_of_service_at=timezone.now())
+
     request.cls.api_client = APIClient()
 
 

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from apps.core.models import Article, Topic, Board, Block, Comment
+from apps.core.models import Article, Topic, Board, Block, Vote, Comment
 from apps.user.models import UserProfile
 from tests.conftest import RequestSetting, TestCase
 
@@ -411,7 +411,7 @@ class TestArticle(TestCase, RequestSetting):
         assert self.article.comment_count == 0
 
 
-@pytest.mark.usefixtures('set_user_client', 'set_board', 'set_topic', 'set_article')
+@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_board', 'set_topic', 'set_article')
 class TestHiddenArticles(TestCase, RequestSetting):
     @staticmethod
     def _user_factory(user_kwargs, profile_kwargs):
@@ -444,6 +444,8 @@ class TestHiddenArticles(TestCase, RequestSetting):
             content_text="example content text",
             is_anonymous=False,
             hit_count=0,
+            is_content_sexual=False,
+            is_content_social=False,
             positive_vote_count=0,
             negative_vote_count=0,
             created_by=self.user,
@@ -553,13 +555,19 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert 'BLOCKED_USER_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.clean_mind_user, target_article, True)
 
-    def test_reported_article_block(self):
-        target_article = self._article_factory(
-            is_content_sexual=False,
-            is_content_social=False,
+    def _create_report_hidden_article(self):
+        return self._article_factory(
             report_count=1000000,
             hidden_at=timezone.now()
         )
+
+    def _create_deleted_article(self):
+        return self._article_factory(
+            deleted_at=timezone.now()
+        )
+
+    def test_reported_article_block(self):
+        target_article = self._create_report_hidden_article()
 
         res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
         assert not res.get('can_override_hidden')
@@ -588,12 +596,7 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert res.get('why_hidden') == ['REPORTED_CONTENT', 'BLOCKED_USER_CONTENT', 'ADULT_CONTENT', 'SOCIAL_CONTENT']
 
     def test_modify_deleted_article(self):
-        target_article = self._article_factory(
-            is_content_sexual=False,
-            is_content_social=False,
-        )
-
-        self.http_request(self.user, 'delete', f'articles/{target_article.id}')
+        target_article = self._create_deleted_article()
 
         new_content = "attempt to modify deleted article"
         res = self.http_request(self.user, 'put', f'articles/{target_article.id}', {
@@ -605,12 +608,7 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert res.status_code == 404
 
     def test_modify_report_hidden_article(self):
-        target_article = self._article_factory(
-            is_content_sexual=False,
-            is_content_social=False,
-            report_count=1000000,
-            hidden_at=timezone.now()
-        )
+        target_article = self._create_report_hidden_article()
 
         new_content = "attempt to modify hidden article"
         res = self.http_request(self.user, 'put', f'articles/{target_article.id}', {
@@ -620,3 +618,85 @@ class TestHiddenArticles(TestCase, RequestSetting):
         })
 
         assert res.status_code == 403
+
+    def test_delete_already_deleted_article(self):
+        target_article = self._create_deleted_article()
+        res = self.http_request(self.user, 'delete', f'articles/{target_article.id}')
+        assert res.status_code == 404
+
+    def test_delete_report_hidden_article(self):
+        target_article = self._create_report_hidden_article()
+        res = self.http_request(self.user, 'delete', f'articles/{target_article.id}')
+        assert res.status_code == 403
+
+    def test_vote_deleted_article(self):
+        target_article = self._create_deleted_article()
+
+        positive_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_positive')
+        assert positive_vote_result.status_code == 404
+
+        negative_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_negative')
+        assert negative_vote_result.status_code == 404
+
+        cancel_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_positive')
+        assert cancel_vote_result.status_code == 404
+
+    def test_vote_report_hidden_article(self):
+        target_article = self._create_report_hidden_article()
+
+        positive_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_positive')
+        assert positive_vote_result.status_code == 403
+
+        negative_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_negative')
+        assert negative_vote_result.status_code == 403
+
+        Vote.objects.create(
+            voted_by=self.user2,
+            parent_article=target_article,
+            is_positive=True,
+        )
+        target_article.update_vote_status()
+
+        cancel_vote_result = self.http_request(self.user2, 'post', f'articles/{target_article.id}/vote_cancel')
+        assert cancel_vote_result.status_code == 403
+        assert Article.objects.get(id=target_article.id).positive_vote_count == 1
+
+    def test_report_deleted_article(self):
+        target_article = self._create_deleted_article()
+
+        res = self.http_request(self.user2, 'post', 'reports', {
+            'content': 'This is a report',
+            'parent_article': target_article.id,
+        })
+
+        assert res.status_code == 403
+
+    def test_report_already_hidden_article(self):
+        target_article = self._create_report_hidden_article()
+
+        res = self.http_request(self.user2, 'post', 'reports', {
+            'content': 'This is a report',
+            'parent_article': target_article.id,
+        })
+
+        assert res.status_code == 403
+
+    def test_comment_on_deleted_article(self):
+        target_article = self._create_deleted_article()
+
+        res = self.http_request(self.user, 'post', 'comments', {
+            'content': 'This is a comment',
+            'parent_article': target_article.id
+        })
+
+        assert res.status_code == 400
+
+    def test_comment_on_report_hidden_article(self):
+        target_article = self._create_report_hidden_article()
+
+        res = self.http_request(self.user, 'post', 'comments', {
+            'content': 'This is a comment',
+            'parent_article': target_article.id
+        })
+
+        assert res.status_code == 201

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -686,7 +686,8 @@ class TestHiddenArticles(TestCase, RequestSetting):
 
         res = self.http_request(self.user, 'post', 'comments', {
             'content': 'This is a comment',
-            'parent_article': target_article.id
+            'parent_article': target_article.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 400
@@ -696,7 +697,8 @@ class TestHiddenArticles(TestCase, RequestSetting):
 
         res = self.http_request(self.user, 'post', 'comments', {
             'content': 'This is a comment',
-            'parent_article': target_article.id
+            'parent_article': target_article.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 201

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -437,15 +437,15 @@ class TestHiddenArticles(TestCase, RequestSetting):
             {'nickname': 'kbdwarrior', 'see_social': True, 'see_sexual': True}
         )
 
-    def _article_factory(self, **article_kwargs):
+    def _article_factory(self, is_content_sexual=False, is_content_social=False, **article_kwargs):
         return Article.objects.create(
             title="example article",
             content="example content",
             content_text="example content text",
             is_anonymous=False,
             hit_count=0,
-            is_content_sexual=False,
-            is_content_social=False,
+            is_content_sexual=is_content_sexual,
+            is_content_social=is_content_social,
             positive_vote_count=0,
             negative_vote_count=0,
             created_by=self.user,

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
-from apps.core.models import Article, Topic, Board, Comment, Block
+from apps.core.models import Article, Topic, Board, Comment, Block, Vote
 from tests.conftest import RequestSetting, TestCase
 
 
@@ -358,11 +358,19 @@ class TestHiddenComments(TestCase, RequestSetting):
         assert 'BLOCKED_USER_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.user, comment2, True)
 
-    def test_reported_comment_block(self):
-        target_comment = self._comment_factory(
+    def _create_report_hidden_comment(self):
+        return self._comment_factory(
             report_count=1000000,
             hidden_at=timezone.now()
         )
+
+    def _create_deleted_comment(self):
+        return self._comment_factory(
+            deleted_at=timezone.now()
+        )
+
+    def test_reported_comment_block(self):
+        target_comment = self._create_report_hidden_comment()
 
         res = self.http_request(self.user, 'get', f'comments/{target_comment.id}').data
         assert not res.get('can_override_hidden')
@@ -375,9 +383,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         self._test_can_override(self.user, target_comment, False)
 
     def test_deleted_comment_block(self):
-        target_comment = self._comment_factory(
-            deleted_at=timezone.now()
-        )
+        target_comment = self._create_deleted_comment()
 
         res = self.http_request(self.user, 'get', f'comments/{target_comment.id}').data
         assert not res.get('can_override_hidden')
@@ -405,9 +411,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         assert res.get('why_hidden') == ['DELETED_CONTENT', 'REPORTED_CONTENT', 'BLOCKED_USER_CONTENT']
 
     def test_modify_deleted_comment(self):
-        target_comment = self._comment_factory(
-            deleted_at=timezone.now()
-        )
+        target_comment = self._create_deleted_comment()
 
         res = self.http_request(self.user, 'patch', f'comments/{target_comment.id}', {
             'content': 'attempt to modify deleted comment',
@@ -415,13 +419,96 @@ class TestHiddenComments(TestCase, RequestSetting):
 
         assert res.status_code == 403
 
-    def test_modify_report_hidden_article(self):
-        target_comment = self._comment_factory(
-            report_count=1000000,
-            hidden_at=timezone.now()
-        )
+    def test_modify_report_hidden_comment(self):
+        target_comment = self._create_report_hidden_comment()
 
         res = self.http_request(self.user, 'patch', f'comments/{target_comment.id}', {
             'content': 'attempt to modify hidden comment'
         })
         assert res.status_code == 403
+
+    def test_delete_already_deleted_comment(self):
+        target_comment = self._create_deleted_comment()
+        res = self.http_request(self.user, 'delete', f'comments/{target_comment.id}')
+        assert res.status_code == 403
+
+    def test_delete_report_hidden_comment(self):
+        target_comment = self._create_report_hidden_comment()
+        res = self.http_request(self.user, 'delete', f'comments/{target_comment.id}')
+        assert res.status_code == 403
+
+    def test_vote_deleted_comment(self):
+        target_comment = self._create_deleted_comment()
+
+        positive_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_positive')
+        assert positive_vote_result.status_code == 403
+
+        negative_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_negative')
+        assert negative_vote_result.status_code == 403
+
+        cancel_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_positive')
+        assert cancel_vote_result.status_code == 403
+
+    def test_vote_report_hidden_article(self):
+        target_comment = self._create_report_hidden_comment()
+
+        positive_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_positive')
+        assert positive_vote_result.status_code == 403
+
+        negative_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_negative')
+        assert negative_vote_result.status_code == 403
+
+        Vote.objects.create(
+            voted_by=self.user2,
+            parent_comment=target_comment,
+            is_positive=True,
+        )
+        target_comment.update_vote_status()
+
+        cancel_vote_result = self.http_request(self.user2, 'post', f'comments/{target_comment.id}/vote_positive')
+        assert cancel_vote_result.status_code == 403
+        assert Comment.objects.get(id=target_comment.id).positive_vote_count == 1
+
+    def test_report_deleted_article(self):
+        target_comment = self._create_deleted_comment()
+
+        res = self.http_request(self.user2, 'post', 'reports', {
+            'content': 'This is a report',
+            'parent_article': target_comment.id,
+        })
+
+        assert res.status_code == 403
+
+    def test_report_already_hidden_comment(self):
+        target_comment = self._create_report_hidden_comment()
+
+        res = self.http_request(self.user2, 'post', 'reports', {
+            'content': 'This is a report',
+            'parent_article': target_comment.id,
+        })
+
+        assert res.status_code == 403
+
+    def test_subcomment_on_deleted_comment(self):
+        target_comment = self._create_deleted_comment()
+
+        subcomment_str = 'this is subcomment'
+        res = self.http_request(self.user, 'post', 'comments', {
+            'content': subcomment_str,
+            'parent_comment': target_comment.id
+        })
+
+        assert res.status_code == 201
+        assert Comment.objects.filter(content=subcomment_str, parent_comment=target_comment.id)
+
+    def test_subcomment_on_report_hidden_comment(self):
+        target_comment = self._create_report_hidden_comment()
+
+        subcomment_str = 'this is subcomment'
+        res = self.http_request(self.user, 'post', 'comments', {
+            'content': subcomment_str,
+            'parent_comment': target_comment.id
+        })
+
+        assert res.status_code == 201
+        assert Comment.objects.filter(content=subcomment_str, parent_comment=target_comment.id)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -475,6 +475,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         res = self.http_request(self.user2, 'post', 'reports', {
             'content': 'This is a report',
             'parent_article': target_comment.id,
+            'parent_comment': None,
             'is_anonymous': False,
         })
 
@@ -486,6 +487,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         res = self.http_request(self.user2, 'post', 'reports', {
             'content': 'This is a report',
             'parent_article': target_comment.id,
+            'parent_comment': None,
             'is_anonymous': False,
         })
 
@@ -497,6 +499,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         subcomment_str = 'this is subcomment'
         res = self.http_request(self.user, 'post', 'comments', {
             'content': subcomment_str,
+            'parent_article': None,
             'parent_comment': target_comment.id,
             'is_anonymous': False,
         })
@@ -510,6 +513,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         subcomment_str = 'this is subcomment'
         res = self.http_request(self.user, 'post', 'comments', {
             'content': subcomment_str,
+            'parent_article': None,
             'parent_comment': target_comment.id,
             'is_anonymous': False,
         })

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -86,7 +86,7 @@ def set_comments(request):
     )
 
 
-@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_board', 'set_topic', 'set_articles', 'set_comments')
+@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_user_client3', 'set_board', 'set_topic', 'set_articles', 'set_comments')
 class TestComments(TestCase, RequestSetting):
     # comment 개수를 확인하는 테스트
     def test_comment_list(self):
@@ -273,8 +273,8 @@ class TestComments(TestCase, RequestSetting):
     # 댓글 좋아요 확인
     def test_positive_vote(self):
         # 좋아요 2표
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_positive')
         self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_positive')
+        self.http_request(self.user3, 'post', f'comments/{self.comment.id}/vote_positive')
 
         comment = Comment.objects.get(id=self.comment.id)
         assert comment.positive_vote_count == 2
@@ -283,8 +283,8 @@ class TestComments(TestCase, RequestSetting):
     # 댓글 싫어요 확인
     def test_negative_vote(self):
         # 싫어요 2표
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_negative')
         self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_negative')
+        self.http_request(self.user3, 'post', f'comments/{self.comment.id}/vote_negative')
 
         comment = Comment.objects.get(id=self.comment.id)
         assert comment.positive_vote_count == 0
@@ -292,24 +292,24 @@ class TestComments(TestCase, RequestSetting):
 
     # 투표 취소 후 재투표 가능한 것 확인
     def test_vote_undo_and_redo(self):
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_positive')
+        self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_positive')
 
         # 투표 취소
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_cancel')
+        self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_cancel')
         comment = Comment.objects.get(id=self.comment.id)
         assert comment.positive_vote_count == 0
         assert comment.negative_vote_count == 0
 
         # 재투표
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_positive')
+        self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_positive')
         comment = Comment.objects.get(id=self.comment.id)
         assert comment.positive_vote_count == 1
         assert comment.negative_vote_count == 0
 
     # 댓글 중복 투표 안되는 것 확인. 중복투표시, 맨 마지막 투표 결과만 유효함
     def test_cannot_vote_both(self):
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_positive')
-        self.http_request(self.user, 'post', f'comments/{self.comment.id}/vote_negative')
+        self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_positive')
+        self.http_request(self.user2, 'post', f'comments/{self.comment.id}/vote_negative')
         comment = Comment.objects.get(id=self.comment.id)
         assert comment.positive_vote_count == 0
         assert comment.negative_vote_count == 1

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -475,6 +475,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         res = self.http_request(self.user2, 'post', 'reports', {
             'content': 'This is a report',
             'parent_article': target_comment.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 403
@@ -485,6 +486,7 @@ class TestHiddenComments(TestCase, RequestSetting):
         res = self.http_request(self.user2, 'post', 'reports', {
             'content': 'This is a report',
             'parent_article': target_comment.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 403
@@ -495,7 +497,8 @@ class TestHiddenComments(TestCase, RequestSetting):
         subcomment_str = 'this is subcomment'
         res = self.http_request(self.user, 'post', 'comments', {
             'content': subcomment_str,
-            'parent_comment': target_comment.id
+            'parent_comment': target_comment.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 201
@@ -507,7 +510,8 @@ class TestHiddenComments(TestCase, RequestSetting):
         subcomment_str = 'this is subcomment'
         res = self.http_request(self.user, 'post', 'comments', {
             'content': subcomment_str,
-            'parent_comment': target_comment.id
+            'parent_comment': target_comment.id,
+            'is_anonymous': False,
         })
 
         assert res.status_code == 201


### PR DESCRIPTION
아래와 같이, O는 허용되고 X는 허용되지 않도록 구현합니다.
각 케이스를 확인하는 테스트코드도 작성합니다.

신고로 숨겨진 글:
- 신고 X
- 좋아요/싫어요 X
- 삭제 X
- 댓글/대댓글 O

삭제된 글:
- 신고 X
- 좋아요/싫어요 X
- 삭제 X
- 댓글/대댓글 X 

신고로 숨겨진 댓글:
- 신고 X
- 좋아요/싫어요 X
- 삭제 X
- 대댓글 O

삭제된 댓글:
- 신고 X
- 좋아요/싫어요 X
- 삭제 X
- 댓글/대댓글 O