### PR TITLE
Update Article, Comment hidden reason ordering

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -228,6 +228,8 @@ class Article(MetaDataModel):
     @cache_by_user
     def hidden_reasons(self, user: settings.AUTH_USER_MODEL) -> typing.List:
         reasons = []
+        if self.is_hidden_by_reported():
+            reasons.append(ArticleHiddenReason.REPORTED_CONTENT)
         if Block.is_blocked(blocked_by=user, user=self.created_by):
             reasons.append(ArticleHiddenReason.BLOCKED_USER_CONTENT)
         if self.is_content_sexual and not user.profile.see_sexual:
@@ -237,7 +239,5 @@ class Article(MetaDataModel):
         # 혹시 몰라 여기 두기는 하는데 여기 오기전에 Permission에서 막혀야 함
         if not self.parent_board.group_has_access(user.profile.group):
             reasons.append(ArticleHiddenReason.ACCESS_DENIED_CONTENT)
-        if self.is_hidden_by_reported():
-            reasons.append(ArticleHiddenReason.REPORTED_CONTENT)
 
         return reasons

--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -189,12 +189,12 @@ class Comment(MetaDataModel):
     def hidden_reasons(self, user: settings.AUTH_USER_MODEL) -> typing.List:
         reasons: typing.List[CommentHiddenReason] = []
 
-        if Block.is_blocked(blocked_by=user, user=self.created_by):
-            reasons.append(CommentHiddenReason.BLOCKED_USER_CONTENT)
-        if self.is_hidden_by_reported():
-            reasons.append(CommentHiddenReason.REPORTED_CONTENT)
         if self.is_deleted():
             reasons.append(CommentHiddenReason.DELETED_CONTENT)
+        if self.is_hidden_by_reported():
+            reasons.append(CommentHiddenReason.REPORTED_CONTENT)
+        if Block.is_blocked(blocked_by=user, user=self.created_by):
+            reasons.append(CommentHiddenReason.BLOCKED_USER_CONTENT)
 
         return reasons
 

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -551,6 +551,22 @@ class TestHiddenArticles(TestCase, RequestSetting):
         assert 'REPORTED_CONTENT' in res.get('why_hidden')
         self._test_can_override(self.clean_mind_user, target_article, False)
 
+    def test_block_reason_order(self):
+        target_article = self._article_factory(
+            is_content_sexual=True,
+            is_content_social=True,
+            report_count=1000000,
+            hidden_at=timezone.now()
+        )
+        Block.objects.create(
+            blocked_by=self.clean_mind_user,
+            user=self.user
+        )
+
+        res = self.http_request(self.clean_mind_user, 'get', f'articles/{target_article.id}').data
+        assert res.get('is_hidden')
+        assert res.get('why_hidden') == ['REPORTED_CONTENT', 'BLOCKED_USER_CONTENT', 'ADULT_CONTENT', 'SOCIAL_CONTENT']
+
     def test_modify_deleted_article(self):
         target_article = self._article_factory(
             is_content_sexual=False,


### PR DESCRIPTION
프런트팀에서 요청한 것과 같이 `why_hidden` 항목을 업데이트합니다.
반영된 순서는 **DELETED_CONTENT (Comment만 해당)** > REPORTED_CONTENT > BLOCKED_USER_CONTENT > ADULT_CONTENT (Article만 해당) > SOCIAL_CONTENT (Article만 해당) 입니다.