### PR TITLE
Fix #269

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -173,7 +173,7 @@ class Article(MetaDataModel):
         self.save()
 
     def update_comment_count(self):
-        self.comment_count = Comment.objects.filter(deleted_at = timezone.datetime.min.replace(tzinfo=timezone.utc)).filter(
+        self.comment_count = Comment.objects.filter(deleted_at=timezone.datetime.min.replace(tzinfo=timezone.utc)).filter(
             models.Q(parent_article=self) |
             models.Q(parent_comment__parent_article=self)
         ).count()

--- a/apps/core/models/signals/on_delete_cascade.py
+++ b/apps/core/models/signals/on_delete_cascade.py
@@ -19,7 +19,7 @@ def cascade_soft_deletion_article(instance, **kwargs):
             instance.article_delete_log_set.all().delete()
             instance.best_set.all().delete()
 
-            comments = instance.comment_set.all().delete()
+            comments = instance.comment_set.filter(deleted_at=timezone.datetime.min.replace(tzinfo=timezone.utc)).delete()
             if comments:
                 instance.update_comment_count()
 

--- a/apps/core/models/signals/on_delete_cascade.py
+++ b/apps/core/models/signals/on_delete_cascade.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.db import models
+from django.db import models, transaction
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -13,22 +13,21 @@ def cascade_soft_deletion_article(instance, **kwargs):
     deleted = instance.deleted_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
 
     if deleted:
-        instance.article_read_log_set.all().delete()
-        instance.article_update_log_set.all().delete()
-        instance.article_delete_log_set.all().delete()
-        instance.best_set.all().delete()
+        with transaction.atomic():
+            instance.article_read_log_set.all().delete()
+            instance.article_update_log_set.all().delete()
+            instance.article_delete_log_set.all().delete()
+            instance.best_set.all().delete()
 
-        comments = instance.comment_set.all().delete()
-        if comments:
-            instance.update_comment_count()
+            comments = instance.comment_set.all().delete()
+            if comments:
+                instance.update_comment_count()
 
-        instance.notification_set.all().delete()
-        instance.report_set.all().delete()
-        instance.scrap_set.all().delete()
-
-        votes = instance.vote_set.all().delete()
-
-        instance.attachments.all().delete()
+            instance.notification_set.all().delete()
+            instance.report_set.all().delete()
+            instance.scrap_set.all().delete()
+            instance.vote_set.all().delete()
+            instance.attachments.all().delete()
 
 
 @receiver(models.signals.post_save, sender=Board)
@@ -36,8 +35,9 @@ def cascade_soft_deletion_board(instance, **kwargs):
     deleted = instance.deleted_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
 
     if deleted:
-        instance.article_set.all().delete()
-        instance.topic_set.all().delete()
+        with transaction.atomic():
+            instance.article_set.all().delete()
+            instance.topic_set.all().delete()
 
 
 @receiver(models.signals.post_save, sender=Comment)
@@ -45,15 +45,15 @@ def cascade_soft_deletion_comment(instance, **kwargs):
     deleted = instance.deleted_at != timezone.datetime.min.replace(tzinfo=timezone.utc)
 
     if deleted:
-        instance.comment_update_log_set.all().delete()
-        instance.comment_delete_log_set.all().delete()
-        instance.notification_set.all().delete()
-        instance.report_set.all().delete()
+        with transaction.atomic():
+            instance.comment_update_log_set.all().delete()
+            instance.comment_delete_log_set.all().delete()
+            instance.notification_set.all().delete()
+            instance.report_set.all().delete()
+            instance.vote_set.all().delete()
 
-        votes = instance.vote_set.all().delete()
-
-        if instance.attachment:
-            instance.attachment.delete()
+            if instance.attachment:
+                instance.attachment.delete()
 
 
 @receiver(models.signals.post_save, sender=Notification)

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -392,14 +392,23 @@ class TestArticle(TestCase, RequestSetting):
 
     # See #269
     def test_deleting_with_comments(self):
+        self.article.comment_count = 1
+        self.article.save()
         Comment.objects.create(
             content='this is a test comment',
             is_anonymous=False,
             created_by=self.user,
             parent_article=self.article
         )
+
         self.http_request(self.user, 'delete', f'articles/{self.article.id}')
-        assert Comment.objects.filter(parent_article=self.article).count() == 0
+        self.article.refresh_from_db()
+
+        assert Comment.objects.filter(
+            parent_article=self.article,
+            deleted_at=timezone.datetime.min.replace(tzinfo=timezone.utc)
+        ).count() == 0
+        assert self.article.comment_count == 0
 
 
 @pytest.mark.usefixtures('set_user_client', 'set_board', 'set_topic', 'set_article')


### PR DESCRIPTION
Fixes #269 ([Sentry](https://sentry.io/organizations/sparcs/issues/2734775717))

Soft deletion signal을 pre_save로 바꾸고, Article.update_comment_count에서 직접 댓글 수를 업데이트 하지 않을 수 있도록 옵션을 주었습니다.
또한 많은 signal에서 DELETE 쿼리가 많음에도 불구하고 원자성이 보장되지 않아 트랜잭션을 걸어주었습니다. Sentry에 보고된 오류 요청도 삭제되다 롤백되지 못한 데이터가 있을 것으로 보입니다.
