### PR TITLE
Admin page 상세보기에서 timeout 문제 해결

### DIFF
--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -101,11 +101,13 @@ class ArticleAdmin(MetaDataModelAdmin):
         'is_anonymous',
         'is_content_sexual',
         'is_content_social',
+        'report_count',
+        'hidden_at',
+    )
+    raw_id_fields = (
         'created_by',
         'parent_topic',
         'parent_board',
-        'report_count',
-        'hidden_at',
     )
     search_fields = (
         'title',
@@ -134,11 +136,12 @@ class CommentAdmin(MetaDataModelAdmin):
         'positive_vote_count',
         'negative_vote_count',
         'is_anonymous',
-        'created_by',
-        'parent_article',
-        'parent_comment',
         'report_count',
         'hidden_at',
+    )
+    raw_id_fields = ('created_by',
+                     'parent_article',
+                     'parent_comment',
     )
     search_fields = (
         'content',


### PR DESCRIPTION
admin page에서 many to many field들이 dropdown으로 보여지기 때문에 timeout이 발생합니다.
기존에 dropdown으로 보여줬던 필드들을 `raw_id`만 보여주도록 수정합니다.

참고: 
Django docs: [ModelAdmin.raw_id_fields](https://docs.djangoproject.com/en/1.11/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields)