### PR TITLE
Prevent non-anonymous comment on anonymous parent

### DIFF
--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -67,7 +67,7 @@ class CommentViewSet(mixins.CreateModelMixin,
             request.data['is_anonymous'] = True
 
         if request.data['is_anonymous']:
-            if (not parent_article_is_anonymous) and (not parent_comment_is_anonymous):
+            if not (parent_article_is_anonymous or parent_comment_is_anonymous):
 
                 return response.Response(
                     {'message': 'Anonymous breakout detected'},

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -54,14 +54,20 @@ class CommentViewSet(mixins.CreateModelMixin,
     }
 
     def create(self, request, *args, **kwargs):
+        parent_article_id = request.data.get('parent_article')
+        parent_comment_id = request.data.get('parent_comment')
+
+        parent_article = parent_article_id and Article.objects.filter(id=parent_article_id).first()
+        parent_comment = parent_comment_id and Comment.objects.filter(id=parent_comment_id).first()
+
+        parent_article_is_anonymous = parent_article and parent_article.is_anonymous
+        parent_comment_is_anonymous = parent_comment and parent_comment.is_anonymous
+
+        if parent_article_is_anonymous or parent_comment_is_anonymous:
+            request.data['is_anonymous'] = True
 
         if request.data['is_anonymous']:
-
-            parent_article_id = request.data['parent_article']
-            parent_comment_id = request.data['parent_comment']
-
-            if any((parent_article_id and not Article.objects.get(pk=parent_article_id).is_anonymous, 
-                    parent_comment_id and not Comment.objects.get(pk=parent_comment_id).is_anonymous)):
+            if (not parent_article_is_anonymous) and (not parent_comment_is_anonymous):
 
                 return response.Response(
                     {'message': 'Anonymous breakout detected'},

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -54,31 +54,20 @@ class CommentViewSet(mixins.CreateModelMixin,
     }
 
     def create(self, request, *args, **kwargs):
-        parent_article_id = request.data.get('parent_article')
-        parent_comment_id = request.data.get('parent_comment')
-
-        parent_article = parent_article_id and Article.objects.filter(id=parent_article_id).first()
-        parent_comment = parent_comment_id and Comment.objects.filter(id=parent_comment_id).first()
-
-        parent_article_is_anonymous = parent_article and parent_article.is_anonymous
-        parent_comment_is_anonymous = parent_comment and parent_comment.is_anonymous
-
-        if parent_article_is_anonymous or parent_comment_is_anonymous:
-            request.data['is_anonymous'] = True
-
-        if request.data['is_anonymous']:
-            if not (parent_article_is_anonymous or parent_comment_is_anonymous):
-
-                return response.Response(
-                    {'message': 'Anonymous breakout detected'},
-                    status=status.HTTP_403_FORBIDDEN
-                )
-
         return super().create(request, *args, **kwargs)
 
     def perform_create(self, serializer):
+        parent_article_id = self.request.data.get('parent_article')
+        parent_article = parent_article_id and Article.objects.filter(id=parent_article_id).first()
+        parent_article_is_anonymous = (parent_article and parent_article.is_anonymous) or False
+
+        parent_comment_id = self.request.data.get('parent_comment')
+        parent_comment = parent_comment_id and Comment.objects.filter(id=parent_comment_id).first()
+        parent_comment_is_anonymous = (parent_comment and parent_comment.is_anonymous) or False
+
         serializer.save(
             created_by=self.request.user,
+            is_anonymous=parent_article_is_anonymous or parent_comment_is_anonymous,
         )
 
     def retrieve(self, request, *args, **kwargs):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -270,6 +270,31 @@ class TestComments(TestCase, RequestSetting):
         comment_auther_id2 = r_comment2.get('created_by')['id']
         assert article_auther_id2 == comment_auther_id2
 
+    def test_comment_on_anonymous_parent(self):
+        # 익명글의 댓글은 is_anonymous 필드를 잘못 주어도 익명으로 생성
+        content1 = 'content for anonymous comment'
+        comment_data = {
+            'content': content1,
+            'parent_article': self.article_anonymous.id,
+            'parent_comment': None,
+            'is_anonymous': False,
+            'attachment': None,
+        }
+        self.http_request(self.user, 'post', 'comments', comment_data)
+        assert Comment.objects.filter(content=content1).first().is_anonymous
+
+        # 익명글의 대댓글은 is_anonymous 필드를 잘못 주어도 익명으로 생성
+        content2 = 'content for anonymous subcomment'
+        subcomment_data = {
+            'content': content2,
+            'parent_comment': self.comment_anonymous.id,
+            'parent_article': None,
+            'is_anonymous': False,
+            'attachment': None,
+        }
+        self.http_request(self.user, 'post', 'comments', subcomment_data)
+        assert Comment.objects.filter(content=content2).first().is_anonymous
+
     # 댓글 좋아요 확인
     def test_positive_vote(self):
         # 좋아요 2표


### PR DESCRIPTION
백엔드에서 댓글의 익명 여부는 프론트에서 보내주는 is_anonymous 필드로 결정합니다.

지난 론칭때, 익명 게시판의 댓글이 실명으로 들어간 문제는 아마도 프론트에서 is_anonymous를 잘못 보내준 것이 아닐까 생각합니다.
(DB에서 해당 댓글의 is_anonymous가 False입니다)

여기서는 프론트에서 is_anonymous가 잘못 들어오더라도, 백에서 다시 확인해서 익명 글 / 익명 댓글에 대한 댓글은 is_anonymous 필드를 True로 바꿔줍니다.

익명 여부를 중복 확인하여 익명성을 보장하려 한 것인데, API 호출자가 주는 is_anonymous 필드를 무시하기 때문에 안좋은 디자인인지 조심스럽습니다.
안좋은 디자인이라면 말씀해주세요.