### PR TITLE
Prevent nonanonymous article on anonymous board

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -119,6 +119,8 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         return queryset
 
     def create(self, request, *args, **kwargs):
+        if request.data['parent_board'] == settings.ANONYMOUS_BOARD_ID:
+            request.data['is_anonymous'] = True
 
         if request.data['is_anonymous'] and request.data['parent_board'] != settings.ANONYMOUS_BOARD_ID :
             return response.Response(


### PR DESCRIPTION
배포했을때 익명 풀린 버그가 브라우저 캐시 때문이어서, 이 PR로 해결됩니다.
익명 게시판에 작성한 모든 글은, `is_anonymous`를 무조건 1로 만듭니다.
사실 프론트에서 `is_anonymous`를 필드로 줄 필요가 없습니다. (추후 프론트 수정 사항)