### PR TITLE
Bump Django to 3.2.9

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -343,7 +343,7 @@ python-versions = "*"
 
 [[package]]
 name = "django"
-version = "3.2.4"
+version = "3.2.9"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
@@ -1407,7 +1407,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bc85c4c4e3080fa879d652885481f744719da90d5356f508eb361f37c798110b"
+content-hash = "36f858359569b1a9fb7c2dc71114fbf06b23220abfed033b8987f678fc98c5a5"
 
 [metadata.files]
 amqp = [
@@ -1593,8 +1593,8 @@ distlib = [
     {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
 ]
 django = [
-    {file = "Django-3.2.4-py3-none-any.whl", hash = "sha256:ea735cbbbb3b2fba6d4da4784a0043d84c67c92f1fdf15ad6db69900e792c10f"},
-    {file = "Django-3.2.4.tar.gz", hash = "sha256:66c9d8db8cc6fe938a28b7887c1596e42d522e27618562517cc8929eb7e7f296"},
+    {file = "Django-3.2.9-py3-none-any.whl", hash = "sha256:e22c9266da3eec7827737cde57694d7db801fedac938d252bf27377cec06ed1b"},
+    {file = "Django-3.2.9.tar.gz", hash = "sha256:51284300f1522ffcdb07ccbdf676a307c6678659e1284f0618e5a774127a6a08"},
 ]
 django-cacheops = [
     {file = "django-cacheops-5.1.tar.gz", hash = "sha256:d5851cd7bf3087384a1fcecfa8dddb8f55030eedfd6fdf127225b75bca0f99dd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.7"
-django = "3.2.4"
 djangorestframework = "^3.12"
 django-s3-storage = "0.13.3"
 django-cors-headers = "^3.1"
@@ -41,6 +40,7 @@ sentry-sdk = "0.19.4"
 django-elasticsearch-dsl = "^7.1.4"
 html5lib = "^1.1"
 pyotp = "^2.6.0"
+Django = "^3.2.9"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4"


### PR DESCRIPTION
현재 버전인 3.2.4에 SQLi 이슈가 있습니다. https://docs.djangoproject.com/en/3.2/releases/3.2.5/
3.2.9까지 breaking change 없이 쭉 버그 픽스라 가장 최신으로 올렸습니다.