### PR TITLE
Fix scrap not deleted when article deleted

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -1,7 +1,6 @@
 import time
 
 from django.db import models
-from django.conf import settings
 from django.utils.translation import gettext
 from rest_framework import status, viewsets, response, decorators, serializers, permissions
 from rest_framework.response import Response
@@ -66,7 +65,10 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 
-        if self.action == 'list':
+        if self.action == 'destroy':
+            pass
+
+        elif self.action == 'list':
             created_by = self.request.query_params.get('created_by')
             if created_by and int(created_by) != self.request.user.id:
                 queryset = queryset.exclude(is_anonymous=True)

--- a/tests/test_scrap.py
+++ b/tests/test_scrap.py
@@ -164,3 +164,11 @@ class TestScrap(TestCase, RequestSetting):
 
         res1 = self.http_request(self.user, 'get', f'articles/{self.article.id}', querystring = 'from_view=scrap')
         assert res1.data['side_articles']['after']['id'] == self.article2.id
+
+    def test_scrap_cascade_delete_when_article_delete(self):
+        Scrap.objects.create(parent_article=self.article2, scrapped_by=self.user)
+        Scrap.objects.create(parent_article=self.article2, scrapped_by=self.user2)
+
+        assert Scrap.objects.filter(parent_article=self.article2).count() == 2
+        self.http_request(self.user2, 'delete', f'articles/{self.article2.id}')  # 작성자가 article2 삭제
+        assert Scrap.objects.filter(parent_article=self.article2).count() == 0


### PR DESCRIPTION
슬렉에서 문의하셨던 "[article 이 삭제될때, 관련 scrap 이 삭제되지 않는 문제](https://sparcs.slack.com/archives/CV6H8N4EM/p1641395417015100)"를 해결하는 PR입니다.

우선 문제가 발생했던 이유는
1. 유저가 직접 article delete API를 날리면,
2. article viewset의 destroy함수를 타게 됩니다.
3. destroy함수에는 get_object 함수가 있고, get_object함수는 제일 먼저 `self.filter_queryset(self.get_queryset())`를 실행시킵니다.
4. article viewset의 filter_queryset을 보면, 지금 action은 destroy로, list가 아니므로 else문을 타게 되고
5. 그러면 쿼리셋 prefetch_related 가 일어나는데, 보시면 `Scrap.prefetch_my_scrap(self.request.user),`가 있었습니다.
6. 그래서 article 중에서도, 내가 스크랩한것만 가져오게 됩니다.
7. 그러니까 그 article에서 .scrap_set.all() 로 스크랩세트를 가져오면, article이 parent_id로 있는 스크랩들 중에서도 내가 스크랩한것만 가져오게 됩니다. -> 그러니까 슬렉에서 이야기 하셨던 `(특이 사항: 본인이 본인글을 scrap 했을 경우, 이 scrap만 삭제가 됩니다)` 같은 현상이 발생하는것이죠. 반면, django admin페이지에서 delete를 시키면, 이 article viewset을 통해서 delete되는게 아니라, `Queryset.delete()`함수를 탑니다. ([django admin페이지에서의 작동 설명](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/actions/))

그래서 제가 수정한 방법은,
delete API 일때는 prefetch_related에서 `Scrap.prefetch_my_scrap(self.request.user),`가 포함되지 않도록, 생각해보니 delete일때는 select_related나 prefetch_related등의 복잡한 로직 탈 필요도 없어서 그냥 따로 뺐어요.

테스트코드도 간단하게 추가했습니다.