### PR TITLE
대댓글 알림에서 related_comment가 parent_comment로 내려가도록 수정

### DIFF
--- a/apps/core/models/notification.py
+++ b/apps/core/models/notification.py
@@ -60,27 +60,27 @@ class Notification(MetaDataModel):
     def notify_commented(cls, comment):
         from apps.core.models import NotificationReadLog
 
-        def notify_article_commented(_article, _comment):
+        def notify_article_commented(_parent_article, _comment):
             NotificationReadLog.objects.create(
-                read_by=_article.created_by,
+                read_by=_parent_article.created_by,
                 notification=cls.objects.create(
                     type='article_commented',
                     title='회원님의 게시물에 새로운 댓글이 작성되었습니다.',
                     content=_comment.content[:32],
-                    related_article=_article,
-                    related_comment=_comment,
+                    related_article=_parent_article,
+                    related_comment=None,
                 ),
             )
 
-        def notify_comment_commented(_article, _comment):
+        def notify_comment_commented(_parent_article, _comment):
             NotificationReadLog.objects.create(
                 read_by=_comment.parent_comment.created_by,
                 notification=cls.objects.create(
                     type='comment_commented',
                     title='회원님의 댓글에 새로운 댓글이 작성되었습니다.',
                     content=_comment.content[:32],
-                    related_article=_article,
-                    related_comment=_comment,
+                    related_article=_parent_article,
+                    related_comment=_comment.parent_comment,
                 ),
             )
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -37,14 +37,14 @@ def set_comment(request):
     )
 
 
-@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_board', 'set_articles')
+@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_board', 'set_articles', 'set_comment')
 class TestNotification(TestCase, RequestSetting):
-    @pytest.mark.usefixtures('set_comment')
     def test_notification_article_commented(self):
         notifications = self.http_request(self.user, 'get', 'notifications')
 
         # user에게 알림: user의 글에 user2가 댓글을 달아서
         assert notifications.status_code == 200
+        assert notifications.data.get('results')[0].get('related_article')['id'] == self.article.id
         assert Notification.objects.all().count() == 1
 
         assert notifications.data.get('num_items') == 1
@@ -60,7 +60,8 @@ class TestNotification(TestCase, RequestSetting):
 
         # user2에게 알림: user2의 댓글에 user가 대댓글을 달아서
         assert notifications.status_code == 200
-        assert Notification.objects.filter(related_comment=cc).count() == 1
+        assert notifications.data.get('results')[0].get('related_comment')['id'] == self.comment.id
+        assert Notification.objects.filter(related_comment=self.comment).count() == 1
 
         assert notifications.data.get('num_items') == 1
 


### PR DESCRIPTION
대댓글 알림에서 related_comment가 기존에는 대댓글 self로 내려갔으나, 이제 parent_comment로 내려가도록 수정하였습니다.