### PR TITLE
Return HTTP 410 for GET requests to deleted articles

### DIFF
--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -655,6 +655,21 @@ class TestHiddenArticles(TestCase, RequestSetting):
 
         assert res.status_code == 403
 
+    def test_get_deleted_article(self):
+        target_article = self._create_deleted_article()
+
+        res = self.http_request(self.user2, 'get', f'articles/{target_article.id}')
+        assert res.status_code == 410
+
+    def test_exclude_deleted_article_from_list(self):
+        target_article = self._create_deleted_article()
+
+        res = self.http_request(self.user2, 'get', f'articles').data
+
+        # user가 글 목록을 가져올 때, 삭제된 글이 목록에 없는 것 확인
+        for post in res.get('results'):
+            assert post.get('id') != target_article.id
+
     def test_delete_already_deleted_article(self):
         target_article = self._create_deleted_article()
         res = self.http_request(self.user, 'delete', f'articles/{target_article.id}')


### PR DESCRIPTION
기존에는 삭제된 게시글에 대하 GET request에 404를 리턴하였습니다.
사용자가 삭제된 글에 접근할 경우, 프론트에서 `삭제된 게시글입니다`로 보여주기 위해 410 Gone을 리턴하도록 수정하였습니다.
이제 처음부터 존재하지 않았던 글은 기존과 같이 404를, 삭제된 글은 410을 리턴하여 프론트에서 상황에 맞게 처리 가능합니다.

`viewsets/article.py`의 `retrieve()`를 수정하였습니다.
` article = self.get_object()`에서 글을 못찾을 경우를 try catch로 처리하여 삭제된 글일 경우 410을, 그 외는 404를 리턴합니다.

테스트 코드도 추가하였습니다.