### PR TITLE
Add has_attachments field to article list serializer

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -332,6 +332,13 @@ class ArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSeriali
         read_only=True,
     )
 
+    has_attachments = serializers.SerializerMethodField(
+        read_only=True,
+    )
+
+    def get_has_attachments(self, obj) -> bool:
+        return self.visible_verdict(obj) and obj.attachments.exists()
+
 
 class BestArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     title = serializers.SerializerMethodField(


### PR DESCRIPTION
프론트에서 게시판을 볼 때, 이미지가 있는 글은 제목 옆에 아이콘으로 표시해달라는 사용자 피드백이 있었습니다.

이에 따라, Article list view에서 각 article의 첨부파일 유무를 표현하는 has_attachments 필드를 추가하였습니다.