### PR TITLE
Show attachment type (img/non-img) in article list view

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -21,7 +21,7 @@ from .report import Report
 from .comment import Comment
 
 
-class ArticleHiddenReason(Enum):
+class ArticleHiddenReason(str, Enum):
     ADULT_CONTENT = 'ADULT_CONTENT'
     SOCIAL_CONTENT = 'SOCIAL_CONTENT'
     REPORTED_CONTENT = 'REPORTED_CONTENT'

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -1,11 +1,10 @@
 import typing
 
-from django.db import models
+from enum import Enum
 from django.utils.translation import gettext
 from rest_framework import serializers
-
 from apps.core.documents import ArticleDocument
-from apps.core.models import Article, ArticleReadLog, Board, Block, Scrap, ArticleHiddenReason
+from apps.core.models import Article, Board, Block, Scrap, ArticleHiddenReason
 from apps.core.serializers.board import BoardSerializer
 from apps.core.serializers.mixins.hidden import HiddenSerializerMixin, HiddenSerializerFieldMixin
 from apps.core.serializers.topic import TopicSerializer
@@ -315,6 +314,13 @@ class ArticleSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     )
 
 
+class ArticleAttachmentType(Enum):
+    NONE = 'NONE'
+    IMAGE = 'IMAGE'
+    NON_IMAGE = 'NON_IMAGE'
+    BOTH = 'BOTH'
+
+
 class ArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
     parent_topic = TopicSerializer(
         read_only=True,
@@ -332,12 +338,28 @@ class ArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSeriali
         read_only=True,
     )
 
-    has_attachments = serializers.SerializerMethodField(
+    attachment_type = serializers.SerializerMethodField(
         read_only=True,
     )
 
-    def get_has_attachments(self, obj) -> bool:
-        return self.visible_verdict(obj) and obj.attachments.exists()
+    def get_attachment_type(self, obj) -> str:
+        if not self.visible_verdict(obj):
+            return ArticleAttachmentType.NONE.value
+
+        has_image = False
+        has_non_image = False
+        for att in obj.attachments.all():
+            if att.mimetype[:5] == 'image':
+                has_image = True
+            else:
+                has_non_image = True
+        if has_image and has_non_image:
+            return ArticleAttachmentType.BOTH.value
+        if has_image:
+            return ArticleAttachmentType.IMAGE.value
+        if has_non_image:
+            return ArticleAttachmentType.NON_IMAGE.value
+        return ArticleAttachmentType.NONE.value
 
 
 class BestArticleListActionSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):


### PR DESCRIPTION
PR #301 에 대한 수정입니다.
게시판의 글들을 보여주는 article list view에서 attachment의 단순 유무 뿐만 아니라, 
`attachment_type` 필드를 통해 attachment의 종류까지 보여줍니다.
종류는 크게 4가지입니다: `NONE`, `IMAGE`, `NON_IMAGE`, `BOTH`

프론트에서 이미지가 있을 경우 게시판에 이미지 아이콘을, 이미지가 아닌 첨부파일이 있을 경우 게시판에 첨부 파일 아이콘을 띄워줄 것 입니다.