### PR TITLE
Fix extension for the path that is not a portal url

### DIFF
--- a/apps/core/management/scripts/portal_crawler.py
+++ b/apps/core/management/scripts/portal_crawler.py
@@ -123,6 +123,8 @@ def _get_article(url, session):
         return new_string
 
     def _get_new_url_and_save_to_s3(url, session):
+        if '.' in url.split('/')[-1]: # not a portal image
+            return url
         enc = hashlib.md5()
         enc.update(url.encode())
         hash = enc.hexdigest()[:20]
@@ -140,7 +142,7 @@ def _get_article(url, session):
         for child in soup.find_all('img', {}):
             old_url = child.attrs.get('src')
             new_url = _get_new_url_and_save_to_s3(old_url, session)
-            child["src"] = new_url
+            child['src'] = new_url
 
         return str(soup)
 


### PR DESCRIPTION
만약 공지 글 안 이미지가 포탈 주소가 아닌 경우에는 이상하게 extension이 붙는 경우가 있었는데 (ex: `files/portal_image_hash.https://....`), 이런 경우에는 그냥 바로 리턴해 줌으로써 해결해 주었습니다.