### PR TITLE
Add my_comment_profile field, minor fix

### DIFF
--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -216,7 +216,6 @@ class Article(MetaDataModel):
         user_hash = hashlib.sha224(user_unique_encoding).hexdigest()
         user_hash_int = int(user_hash[-4:], 16)
         user_profile_picture = get_profile_picture(user_hash_int)
-        user_profile_picture_realname = get_profile_picture(self.created_by.id + HASH_SECRET_VALUE)
 
         if self.name_type == BoardNameType.ANONYMOUS:
             return {
@@ -237,7 +236,7 @@ class Article(MetaDataModel):
                 'id': user_unique_num,
                 'username': user_realname,
                 'profile': {
-                    'picture': default_storage.url(user_profile_picture_realname),
+                    'picture': default_storage.url(user_profile_picture),
                     'nickname': user_realname,
                     'user': user_realname
                 },

--- a/apps/core/models/comment.py
+++ b/apps/core/models/comment.py
@@ -190,8 +190,11 @@ class Comment(MetaDataModel):
         
         if self.name_type == BoardNameType.REALNAME:
             sso_info = self.created_by.profile.sso_user_info
-            user_realname = json.loads(sso_info["kaist_info"])["ku_kname"] if sso_info["kaist_info"] else sso_info["last_name"] + sso_info["first_name"]
-
+            if parent_article_created_by_id == comment_created_by_id:
+                user_realname = gettext('author')
+            else:
+                user_realname = json.loads(sso_info["kaist_info"])["ku_kname"] if sso_info["kaist_info"] else sso_info["last_name"] + sso_info["first_name"]
+            
             return {
                 'id': user_unique_num,
                 'username': user_realname,

--- a/apps/core/views/viewsets/comment.py
+++ b/apps/core/views/viewsets/comment.py
@@ -60,17 +60,10 @@ class CommentViewSet(mixins.CreateModelMixin,
     def perform_create(self, serializer):
         parent_article_id = self.request.data.get('parent_article')
         parent_article = parent_article_id and Article.objects.get(id=parent_article_id)
-        parent_article_name_type = parent_article and parent_article.name_type
-
         parent_comment_id = self.request.data.get('parent_comment')
         parent_comment = parent_comment_id and Comment.objects.get(id=parent_comment_id)
-        parent_comment_name_type = parent_comment and parent_comment.name_type
 
-        name_type = BoardNameType.REGULAR
-        for ntype in (BoardNameType.ANONYMOUS, BoardNameType.REALNAME):
-            if parent_article_name_type == ntype or parent_comment_name_type == ntype:
-                name_type = ntype
-                break
+        name_type = parent_article.name_type if parent_article else parent_comment.name_type
 
         serializer.save(
             created_by=self.request.user,


### PR DESCRIPTION
1. `article` 에  `my_comment_profile` 라는 필드를 추가했습니다. 기존에는 프론트에서 복잡한 방식으로 댓글 작성 창의 익명 여부와 프로필을 결정했지만, 실명까지 생김에 따라 프론트서 완벽히 구현이 불가능할 뿐더러 쉽게 버그가 날 가능성이 높아 보였습니다. 대신 간단히 백엔드에서 가짜 댓글을 만들어 `postprocessed_created_by` 에 의해 생성되는 **현재 요청을 보낸 사용자**의 댓글 프로필을 보내줍니다. `created_by` 와 완전히 구조가 같습니다.
2. 실명 게시판 목록에서 프로필 이미지로 `user_profile_picture_realname` 을 썼었던 방식을 없애기로 했습니다. (동명 이인을 굳이 구분 지을 필요는 없기 때문에)
3. 댓글이 실명인 경우에도 "글쓴이" 라는 텍스트가 보여지도록 했습니다.

기존의 프론트엔드에서 익명일때 어떻게 보여주었는지는 https://github.com/sparcs-kaist/new-ara-web/pull/313 의 diff 이전 코드를 참고해 주세요