### PR TITLE
Remove duplicated created_by in CommentSerializer

### DIFF
--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -44,9 +44,6 @@ class BaseCommentSerializer(HiddenSerializerMixin, MetaDataModelSerializer):
 
 class CommentSerializer(HiddenSerializerFieldMixin, BaseCommentSerializer):
     from apps.user.serializers.user import PublicUserSerializer
-    created_by = PublicUserSerializer(
-        read_only=True,
-    )
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )
@@ -63,9 +60,6 @@ class CommentSerializer(HiddenSerializerFieldMixin, BaseCommentSerializer):
 
 class CommentListActionSerializer(HiddenSerializerFieldMixin, BaseCommentSerializer):
     from apps.user.serializers.user import PublicUserSerializer
-    created_by = PublicUserSerializer(
-        read_only=True,
-    )
     my_vote = serializers.SerializerMethodField(
         read_only=True,
     )


### PR DESCRIPTION
`CommentSerializer`와 `CommentListActionSerializer`에 중복으로 존재하던 `created_by`를 하나씩 제거하였습니다.