### PR TITLE
fix portal crawler to handle exceptional html format

### DIFF
--- a/apps/core/management/scripts/portal_crawler.py
+++ b/apps/core/management/scripts/portal_crawler.py
@@ -141,6 +141,12 @@ def _get_article(url, session):
             html = tr.find('td').prettify()
             break
 
+    if html is None:
+        for tr in trs:
+            if len(list(tr.children)) == 2:
+                html = tr.find('td').prettify()
+                break
+
     html = _save_portal_image(html, session)
     html = _enable_hyperlink(html)
 


### PR DESCRIPTION
어제 작업한거랑 상관 없는 에러가 있어 고쳤어요.
장기적으로 한 글이 실패해도 전부가 실패하지 않는 로직으로 고쳐야합니다.
현재 N개 중 하나라도 fail하면 전체 실패하는 로직이라 우선은 이것만 고쳐서 배포해놓고 다음 티켓에서 try catch로 수정할게요