### PR TITLE
Add ban cancellation vote over threshold in realname article

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -9,6 +9,7 @@ from apps.core.models.board import BoardNameType
 
 from ara import redis
 from ara.classes.viewset import ActionAPIViewSet
+from ara.settings import SCHOOL_RESPONSE_VOTE_THRESHOLD
 
 from apps.core.models import (
     Article,
@@ -212,6 +213,10 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     @decorators.action(detail=True, methods=['post'])
     def vote_cancel(self, request, *args, **kwargs):
         article = self.get_object()
+
+        if article.name_type == BoardNameType.REALNAME and article.positive_vote_count >= SCHOOL_RESPONSE_VOTE_THRESHOLD:
+            return response.Response({'message': gettext('Cannot cancel vote on more than 30 votes in realname article')},
+                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         if article.is_hidden_by_reported():
             return response.Response({'message': gettext('Cannot cancel vote on articles hidden by reports')},

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -214,13 +214,13 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     def vote_cancel(self, request, *args, **kwargs):
         article = self.get_object()
 
-        if article.name_type == BoardNameType.REALNAME and article.positive_vote_count >= SCHOOL_RESPONSE_VOTE_THRESHOLD:
-            return response.Response({'message': gettext('Cannot cancel vote on more than 30 votes in realname article')},
-                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
-
         if article.is_hidden_by_reported():
             return response.Response({'message': gettext('Cannot cancel vote on articles hidden by reports')},
                                      status=status.HTTP_403_FORBIDDEN)
+
+        if article.name_type == BoardNameType.REALNAME and article.positive_vote_count >= SCHOOL_RESPONSE_VOTE_THRESHOLD:
+            return response.Response({'message': gettext('It is not available to cancel a vote for a real name article with more than 30 votes.')},
+                                     status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         if not Vote.objects.filter(
             voted_by=request.user,

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -575,7 +575,7 @@ class TestRealnameArticle(TestCase, RequestSetting):
         assert result.get('name_type') == BoardNameType.REALNAME
         assert Article.objects.get(title=new_title).name_type == BoardNameType.REALNAME
 
-    def test_ban_vote_canclellation_after_30(self):
+    def test_ban_vote_cancellation_after_30(self):
         # SCHOOL_RESPONSE_VOTE_THRESHOLD is 3 in test
         users = [self.user, self.user2]
         for user in users:

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 from apps.core.models import Article, Topic, Board, Block, Vote, Comment
 from apps.core.models.board import BoardNameType
 from apps.user.models import UserProfile
+from ara.settings import SCHOOL_RESPONSE_VOTE_THRESHOLD
 from tests.conftest import RequestSetting, TestCase
 
 
@@ -78,6 +79,25 @@ def set_articles(request):
             parent_topic=request.cls.topic,
             parent_board=request.cls.board,
             commented_at=timezone.now()
+    )
+
+@pytest.fixture(scope='class')
+def set_realname_article(request):
+    """set_user_with_kaist_info,, set_realname_topic, set_realname_board 먼저 적용"""
+    request.cls.realname_article = Article.objects.create(
+        title='Realname Test Article',
+        content='Content of test realname article',
+        content_text='Content of test article in text',
+        name_type=BoardNameType.REALNAME,
+        is_content_sexual=False,
+        is_content_social=False,
+        hit_count=0,
+        positive_vote_count=0,
+        negative_vote_count=0,
+        created_by=request.cls.user_with_kaist_info,
+        parent_topic=request.cls.realname_topic,
+        parent_board=request.cls.realname_board,
+        commented_at=timezone.now()
     )
 
 
@@ -463,8 +483,8 @@ class TestArticle(TestCase, RequestSetting):
         ).count() == 0
         assert self.article.comment_count == 0
 
-@pytest.mark.usefixtures('set_user_client', 'set_user_with_kaist_info', 'set_user_without_kaist_info',
-                         'set_boards', 'set_topics', 'set_articles')
+@pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_user_with_kaist_info', 'set_user_without_kaist_info',
+                         'set_boards', 'set_topics', 'set_articles', 'set_realname_article')
 class TestRealnameArticle(TestCase, RequestSetting):
     def test_get_realname_article(self):
         # kaist info가 있는 유저가 생성한 게시글
@@ -553,6 +573,23 @@ class TestRealnameArticle(TestCase, RequestSetting):
 
         assert result.get('name_type') == BoardNameType.REALNAME
         assert Article.objects.get(title=new_title).name_type == BoardNameType.REALNAME
+
+    def test_ban_canclellation_vote_after_30(self):
+        # SCHOOL_RESPONSE_VOTE_THRESHOLD is 3 in test
+        users = [self.user, self.user2]
+        for user in users:
+            self.http_request(user, 'post', f'articles/{self.realname_article.id}/vote_positive')
+
+        res1 = self.http_request(self.user_without_kaist_info, 'post', f'articles/{self.realname_article.id}/vote_positive')
+        article = Article.objects.get(id=self.realname_article.id)
+        assert res1.status_code == 200
+        assert article.positive_vote_count == SCHOOL_RESPONSE_VOTE_THRESHOLD
+
+        res2 = self.http_request(self.user_without_kaist_info, 'post', f'articles/{self.realname_article.id}/vote_cancel')
+        article = Article.objects.get(id=self.realname_article.id)
+        assert res2.status_code == 405
+        assert article.positive_vote_count == SCHOOL_RESPONSE_VOTE_THRESHOLD
+
 
 @pytest.mark.usefixtures('set_user_client', 'set_user_client2', 'set_user_with_kaist_info', 'set_user_without_kaist_info',
                          'set_boards', 'set_topics', 'set_articles')

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
 from rest_framework.test import APIClient
+from rest_framework import status
 
 from apps.core.models import Article, Topic, Board, Block, Vote, Comment
 from apps.core.models.board import BoardNameType
@@ -574,7 +575,7 @@ class TestRealnameArticle(TestCase, RequestSetting):
         assert result.get('name_type') == BoardNameType.REALNAME
         assert Article.objects.get(title=new_title).name_type == BoardNameType.REALNAME
 
-    def test_ban_canclellation_vote_after_30(self):
+    def test_ban_vote_canclellation_after_30(self):
         # SCHOOL_RESPONSE_VOTE_THRESHOLD is 3 in test
         users = [self.user, self.user2]
         for user in users:
@@ -582,12 +583,12 @@ class TestRealnameArticle(TestCase, RequestSetting):
 
         res1 = self.http_request(self.user_without_kaist_info, 'post', f'articles/{self.realname_article.id}/vote_positive')
         article = Article.objects.get(id=self.realname_article.id)
-        assert res1.status_code == 200
+        assert res1.status_code == status.HTTP_200_OK
         assert article.positive_vote_count == SCHOOL_RESPONSE_VOTE_THRESHOLD
 
         res2 = self.http_request(self.user_without_kaist_info, 'post', f'articles/{self.realname_article.id}/vote_cancel')
         article = Article.objects.get(id=self.realname_article.id)
-        assert res2.status_code == 405
+        assert res2.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
         assert article.positive_vote_count == SCHOOL_RESPONSE_VOTE_THRESHOLD
 
 


### PR DESCRIPTION
실명게시판에서 좋아요 30개 이상일 때 취소할 수 없게 만들었습니다.
30개 이상일 때 취소하려고 시도하면 405가 나옵니다.
테스트 케이스도 추가했습니다.