### PR TITLE
Fix/add is school admin to user profile

### DIFF
--- a/apps/core/serializers/comment.py
+++ b/apps/core/serializers/comment.py
@@ -94,8 +94,7 @@ class CommentCreateActionSerializer(BaseCommentSerializer):
             'created_by',
         )
 
-    from apps.user.serializers.user import PublicUserSerializer
-    created_by = PublicUserSerializer(
+    created_by = serializers.SerializerMethodField(
         read_only=True,
     )
 

--- a/tests/test_communication_article.py
+++ b/tests/test_communication_article.py
@@ -137,7 +137,8 @@ class TestCommunicationArticle(TestCase, RequestSetting):
             'created_by': self.school_admin.id,
             'parent_article': article.id
         }
-        self.http_request(self.school_admin, 'post', 'comments', comment_data)
+        res = self.http_request(self.school_admin, 'post', 'comments', comment_data)
+        assert res.data.get('created_by').get('profile').get('is_school_admin')
 
     # status를 가지는 communication_article 반환
     def _create_article_with_status(self, status=SchoolResponseStatus.BEFORE_UPVOTE_THRESHOLD):


### PR DESCRIPTION
#332 에서 is_school_admin을 보내주는 로직을 리팩토링하면서 방금 생성된 댓글에 대해서는 작성자가 postprocess_created_by 로직을 타지 않는 문제가 있었습니다.
CommentCreateSerializer 필드를 수정하여 댓글 생성시에도 작성자 후처리가 되어 is_school_admin을 잘 보내주도록 하였습니다.