### PR TITLE
Add reminder email for communication board reply

### DIFF
--- a/apps/core/management/scripts/reminder_email_for_reply.py
+++ b/apps/core/management/scripts/reminder_email_for_reply.py
@@ -1,0 +1,103 @@
+from django.utils import timezone, dateformat
+from django.core.mail import send_mail
+
+from apps.core.models import CommunicationArticle, UserProfile
+from ara.settings import env
+
+
+if env('DJANGO_ENV') == 'production':
+    django_env = ''
+    BASE_URL = 'https://newara.sparcs.org/post'
+else:
+    django_env = '[DEV]'
+    BASE_URL = 'https://newara.dev.sparcs.org/post'
+
+
+def _get_preparing_articles():
+    articles = CommunicationArticle.objects.filter(
+        school_response_status=1,
+    ).order_by('response_deadline')
+
+    return articles
+
+
+# 답변일까지 13일, 7일, 1일이 남았을 때 reminder 메일 발송
+def _is_remind_day(articles):
+    days_left_to_remind = [13, 7, 1]
+
+    for article in articles:
+        if article.days_left in days_left_to_remind:
+            return True
+
+    return False
+
+
+def _format_date(date):
+    return dateformat.format(date, 'Y-m-d')
+
+
+def _format_dday(days_left):
+    if days_left < 0:
+        dday = f'[D+{days_left * -1}]'
+    elif days_left == 0:
+        dday = '[D-Day]'
+    else:
+        dday = f'[D-{days_left}]'
+
+    return dday
+
+
+def _make_title():
+    return f"[NewAra]{django_env} {_format_date(timezone.localtime())} '학교에게 전합니다' 답변대기 목록"
+
+
+def _make_message(articles):
+    new_message_list = ""
+    old_message_list = ""
+
+    num_new_message = 0
+    num_old_message = 0
+
+    for article in articles:
+        url = f"{BASE_URL}/{article.article_id}"
+        message = f"{_format_dday(article.days_left)} {_format_date(article.response_deadline)} '{article.article.title}' {url}\n"
+
+        if article.days_left == 13:
+            new_message_list += message
+            num_new_message += 1
+        else:
+            old_message_list += message
+            num_old_message += 1
+
+    new_message_header = f"새로운 답변 대기 목록 {num_new_message}개\n"
+    old_message_header = f"\n기존 답변 대기 목록 {num_old_message}개\n"
+
+    return new_message_header + new_message_list + old_message_header + old_message_list
+
+
+def _get_mailing_list():
+    mailing_list = []
+
+    admin_users = UserProfile.objects.filter(
+        group=6
+    ).values('sso_user_info')
+
+    for user in admin_users:
+        mailing_list.append(user['sso_user_info']['email'])
+
+    return mailing_list
+
+
+def send_email():
+    preparing_articles = _get_preparing_articles()
+
+    if not _is_remind_day(preparing_articles):
+        return
+
+    title = _make_title()
+
+    message = _make_message(preparing_articles)
+
+    mailing_list = _get_mailing_list()
+
+    send_mail(title, message, 'new-ara@sparcs.org', mailing_list)

--- a/apps/core/management/tasks.py
+++ b/apps/core/management/tasks.py
@@ -2,6 +2,7 @@ import time
 from collections import defaultdict
 
 from apps.core.management.scripts.portal_crawler import crawl_hour
+from apps.core.management.scripts.reminder_email_for_reply import send_email
 from apps.core.models import BestArticle
 from ara import celery_app, redis
 
@@ -66,3 +67,8 @@ def save_daily_best():
 @celery_app.task
 def save_weekly_best():
     return _get_best(7, BestArticle.PERIOD_CHOICES_WEEKLY)
+
+
+@celery_app.task
+def send_email_for_reply_reminder():
+    send_email()

--- a/ara/celery.py
+++ b/ara/celery.py
@@ -37,4 +37,9 @@ app.conf.beat_schedule = {
         'schedule': settings.SCHEDULERS['SAVE_WEEKLY_BEST']['CRONTAB'],
         'args': []
     },
+    'send_email_for_reply_reminder': {
+        'task': 'apps.core.management.tasks.send_email_for_reply_reminder',
+        'schedule': settings.SCHEDULERS['SEND_EMAIL_FOR_REPLY_REMINDER']['CRONTAB'],
+        'args': []
+    },
 }

--- a/ara/settings/scheduler.py
+++ b/ara/settings/scheduler.py
@@ -25,9 +25,10 @@ def create_scheduler_config(name, period=None, crontab=None):
         config['CRONTAB'] = crontab
     return config
 
-
 SCHEDULERS = {
     'CRAWL_PORTAL': create_scheduler_config('CRAWL_PORTAL', crontab=crontab(minute=0)),  # 매 0분 (1시간마다)
     'SAVE_DAILY_BEST': create_scheduler_config('SAVE_DAILY_BEST', crontab=crontab(minute=0)),
     'SAVE_WEEKLY_BEST': create_scheduler_config('SAVE_WEEKLY_BEST', crontab=crontab(minute=0)),
+    'SEND_EMAIL_FOR_REPLY_REMINDER': create_scheduler_config('SEND_EMAIL_FOR_REPLY_REMINDER', crontab=crontab(hour=7, minute=0)),  # 매일 오전 7시
 }
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50014431/187443255-73095464-3c2e-492a-9f6d-62a5a783abbf.png)

'학교에게 전합니다' 게시물 공감수 달성 기준을 달성했을 때, 학교 관리자에게 메일을 발송하는 기능입니다.
양식은 위와 같이 발송합니다.

1. 매일 오전 7시에 celery가 돌고 답변대기목록에 13일,7일,1일이 남은 답변대기가 있을 때 메일 발송 합니다.
2. user DB에서 group 6인 관리자 모두에게 발송합니다.

