### PR TITLE
Restore auto() in Enum to fixed integers

### DIFF
--- a/apps/core/models/board.py
+++ b/apps/core/models/board.py
@@ -7,15 +7,15 @@ from ara.db.models import MetaDataModel
 
 
 class BoardNameType(IntEnum):
-    REGULAR = auto()
-    ANONYMOUS = auto()
-    REALNAME = auto()
+    REGULAR = 0
+    ANONYMOUS = 1
+    REALNAME = 2
 
 
 class BoardAccessPermissionType(IntEnum):
-    READ = auto()
-    WRITE = auto()
-    COMMENT = auto()
+    READ = 0
+    WRITE = 1
+    COMMENT = 2
 
 
 class Board(MetaDataModel):


### PR DESCRIPTION
`BoardNameType`과 `BoardAccessPermissionType`의 `auto()`를 integer로 복원하였습니다.