### PR TITLE
Make NewAra profile official

### DIFF
--- a/apps/user/models/user_profile.py
+++ b/apps/user/models/user_profile.py
@@ -143,7 +143,10 @@ class UserProfile(MetaDataModel):
 
     @cached_property
     def is_official(self) -> bool:
-        return self.group in UserProfile.OFFICIAL_GROUPS
+        return (
+            self.group in UserProfile.OFFICIAL_GROUPS
+            or self.user.email == "new-ara@sparcs.org"
+        )
 
     @cached_property
     def is_school_admin(self) -> bool:


### PR DESCRIPTION
`UserProfile.is_official` is also `true` if email is <new-ara@sparcs.org>. (It is for putting a verified badge.)