### PR TITLE
Fix school admin profile to nickname profile at comment

### DIFF
--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -322,12 +322,18 @@ class ArticleSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
         return None
 
     def get_my_comment_profile(self, obj):
+        created_by = self.context["request"].user
+        name_type = obj.name_type
+
+        if obj.parent_board.id == 14 and created_by.profile.is_school_admin:
+            name_type = BoardNameType.REGULAR
+
         fake_comment = Comment(
-            created_by=self.context["request"].user,
-            name_type=obj.name_type,
+            created_by=created_by,
+            name_type=name_type,
             parent_article=obj,
         )
-        if obj.name_type in (BoardNameType.ANONYMOUS, BoardNameType.REALNAME):
+        if fake_comment.name_type in (BoardNameType.ANONYMOUS, BoardNameType.REALNAME):
             return fake_comment.postprocessed_created_by
         else:
             data = PublicUserSerializer(fake_comment.postprocessed_created_by).data

--- a/apps/core/serializers/article.py
+++ b/apps/core/serializers/article.py
@@ -325,7 +325,10 @@ class ArticleSerializer(HiddenSerializerFieldMixin, BaseArticleSerializer):
         created_by = self.context["request"].user
         name_type = obj.name_type
 
-        if obj.parent_board.id == 14 and created_by.profile.is_school_admin:
+        if (
+            obj.parent_board.is_school_communication
+            and created_by.profile.is_school_admin
+        ):
             name_type = BoardNameType.REGULAR
 
         fake_comment = Comment(

--- a/apps/user/serializers/user_profile.py
+++ b/apps/user/serializers/user_profile.py
@@ -72,6 +72,7 @@ class PublicUserProfileSerializer(BaseUserProfileSerializer):
             "nickname",
             "user",
             "is_official",
+            "is_school_admin",
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,27 @@ def set_user_without_kaist_info(request):
     request.cls.api_client = APIClient()
 
 
+@pytest.fixture(scope="class")
+def set_school_admin(request):
+    request.cls.school_admin, _ = User.objects.get_or_create(
+        username="School Admin", email="schooladmin@sparcs.org"
+    )
+    if not hasattr(request.cls.school_admin, "profile"):
+        UserProfile.objects.get_or_create(
+            user=request.cls.school_admin,
+            nickname="School Admin",
+            agree_terms_of_service_at=timezone.now(),
+            group=UserProfile.UserGroup.COMMUNICATION_BOARD_ADMIN,
+            sso_user_info={
+                "kaist_info": '{"ku_kname": "\\ud669"}',
+                "first_name": "FirstName",
+                "last_name": "LastName",
+            },
+        )
+
+    request.cls.api_client = APIClient()
+
+
 class RequestSetting:
     def http_request(self, user, method, path, data=None, querystring="", **kwargs):
         self.api_client.force_authenticate(user=user)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -522,6 +522,7 @@ class TestComments(TestCase, RequestSetting):
     "set_user_client",
     "set_user_with_kaist_info",
     "set_user_without_kaist_info",
+    "set_school_admin",
     "set_boards",
     "set_topics",
     "set_articles",
@@ -598,6 +599,40 @@ class TestRealnameComments(TestCase, RequestSetting):
         assert res.get("name_type") == BoardNameType.REALNAME
         assert (
             Comment.objects.get(content=comment_str).name_type == BoardNameType.REALNAME
+        )
+
+    def test_create_school_admin_comment(self):
+        comment_str = "This is a school_admin comment on a realname article"
+        comment_data = {
+            "content": comment_str,
+            "parent_article": self.realname_article.id,
+            "parent_comment": None,
+            "attachment": None,
+        }
+
+        res = self.http_request(
+            self.school_admin, "post", "comments", comment_data
+        ).data
+        assert res.get("name_type") == BoardNameType.REGULAR
+        assert (
+            Comment.objects.get(content=comment_str).name_type == BoardNameType.REGULAR
+        )
+
+    def test_create_school_admin_subcomment(self):
+        comment_str = "This is a school_admin subcomment on a realname comment"
+        comment_data = {
+            "content": comment_str,
+            "parent_article": None,
+            "parent_comment": self.realname_comment.id,
+            "attachment": None,
+        }
+
+        res = self.http_request(
+            self.school_admin, "post", "comments", comment_data
+        ).data
+        assert res.get("name_type") == BoardNameType.REGULAR
+        assert (
+            Comment.objects.get(content=comment_str).name_type == BoardNameType.REGULAR
         )
 
 

--- a/tests/test_communication_article.py
+++ b/tests/test_communication_article.py
@@ -30,7 +30,6 @@ def set_communication_board(request):
         en_description="With School (Test)",
         is_school_communication=True,
         name_type=BoardNameType.REALNAME,
-        id=14,
         read_access_mask=0b11011110,
         write_access_mask=0b11011010,
     )

--- a/tests/test_communication_article.py
+++ b/tests/test_communication_article.py
@@ -21,26 +21,6 @@ from tests.conftest import RequestSetting, TestCase
 
 
 @pytest.fixture(scope="class")
-def set_school_admin(request):
-    request.cls.school_admin, _ = User.objects.get_or_create(
-        username="School Admin", email="schooladmin@sparcs.org"
-    )
-    if not hasattr(request.cls.school_admin, "profile"):
-        UserProfile.objects.get_or_create(
-            user=request.cls.school_admin,
-            nickname="School Admin",
-            agree_terms_of_service_at=timezone.now(),
-            group=UserProfile.UserGroup.COMMUNICATION_BOARD_ADMIN,
-            sso_user_info={
-                "kaist_info": '{"ku_kname": "\\ud669"}',
-                "first_name": "FirstName",
-                "last_name": "LastName",
-            },
-        )
-    request.cls.api_client = APIClient()
-
-
-@pytest.fixture(scope="class")
 def set_communication_board(request):
     request.cls.communication_board = Board.objects.create(
         slug="with-school",
@@ -50,6 +30,7 @@ def set_communication_board(request):
         en_description="With School (Test)",
         is_school_communication=True,
         name_type=BoardNameType.REALNAME,
+        id=14,
         read_access_mask=0b11011110,
         write_access_mask=0b11011010,
     )
@@ -436,3 +417,19 @@ class TestCommunicationArticle(TestCase, RequestSetting):
         }
         res = self.http_request(self.user, "post", "comments", comment_data).data
         assert res.get("name_type") == BoardNameType.REALNAME
+
+    # ======================================================================= #
+    #                               School Admin                              #
+    # ======================================================================= #
+
+    # school_admin이 작성할 때 my_comment_profile REGULAR 확인
+    def test_school_admin_my_comment_profile(self):
+        res = self.http_request(
+            self.school_admin, "get", f"articles/{self.article.id}"
+        ).data
+
+        assert res.get("my_comment_profile")["profile"]["is_school_admin"]
+        assert (
+            res.get("my_comment_profile")["profile"]["nickname"]
+            == UserProfile.objects.get(user_id=self.school_admin.id).nickname
+        )


### PR DESCRIPTION
1. "학교에게 전합니다" 게시판에서 school admin이 댓글을 작성했을 때 실명이 아닌 닉네임 타입으로 작성하게 변경했습니다.

2. Comment editor도 닉네임 타입으로 변경했습니다.
- Comment editor에도 공식마크 달기 위해서 프론트 작업이 필요할 것 같습니다.

4. 테스트 코드 작성했습니다.