### PR TITLE
Use unique names for attachments

### DIFF
--- a/apps/core/models/attachment.py
+++ b/apps/core/models/attachment.py
@@ -1,15 +1,24 @@
+import os
+import uuid
+
 from django.db import models
 
 from ara.db.models import MetaDataModel
 
 
 class Attachment(MetaDataModel):
+    def _hash_filename(instance, filename):
+        s3_folder = "files/"
+        _, extension = os.path.splitext(filename)
+        unique_filename = str(uuid.uuid4()) + extension
+        return os.path.join(s3_folder, unique_filename)
+
     class Meta(MetaDataModel.Meta):
         verbose_name = "첨부파일"
         verbose_name_plural = "첨부파일 목록"
 
     file = models.FileField(
-        upload_to="files",
+        upload_to=_hash_filename,
         verbose_name="링크",
         max_length=200,
     )


### PR DESCRIPTION
첨부파일 업로드 시 사용자가 작성한 파일명으로 업로드되던 로직을 `uuid4`를 사용하도록 수정하였습니다.
Related issue #52