### PR TITLE
Change runner to bap server & Disable FCM

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -24,7 +24,9 @@ env:
 jobs:
   deploy:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    # runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/ara/firebase.py
+++ b/ara/firebase.py
@@ -4,6 +4,9 @@ from apps.user.models import FCMToken
 
 
 def fcm_notify_comment(user, title, body, open_url):
+    ################## Disable FCM ####################
+    return
+
     targets = FCMToken.objects.filter(user=user)
     for i in targets:
         try:
@@ -16,6 +19,9 @@ def fcm_notify_comment(user, title, body, open_url):
 def fcm_simple(FCM_token, title="Title", body="Body", open_url="/"):
     # This registration token comes from the client FCM SDKs.
     # See documentation on defining a message payload.
+
+    ################## Disable FCM ####################
+    return
     message = messaging.Message(
         notification=messaging.Notification(
             title=title,


### PR DESCRIPTION
주의: 밥 서버가 죽게 되는 경우 runner가 돌지 못합니다. 이 경우 주석 처리한 부분으로 다시 되돌리셔야 합니다.
+ 추가: release를 위한 FCM 관련 부분을 비활성화 했습니다.