### PR TITLE
Fix article board group N+1 query problem

### DIFF
--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -108,6 +108,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 "created_by__profile",
                 "parent_topic",
                 "parent_board",
+                "parent_board__group",
             ).prefetch_related(
                 ArticleReadLog.prefetch_my_article_read_log(self.request.user),
             )
@@ -119,6 +120,7 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
                 "created_by__profile",
                 "parent_topic",
                 "parent_board",
+                "parent_board__group",
             ).prefetch_related(
                 "attachments",
                 models.Prefetch(


### PR DESCRIPTION
Join `boardgroup` table when selecting articles:

```sql
SELECT ...
FROM `core_article`
  ...
    INNER JOIN `core_board`
      ON (`core_article`.`parent_board_id` = `core_board`.`id`)
    LEFT OUTER JOIN `core_boardgroup`
      ON (`core_board`.`group_id` = `core_boardgroup`.`id`)
...
```