### PR TITLE
[Hotfix] Remove index using created_at to prevent performance issue

### DIFF
--- a/apps/core/migrations/0057_alter_article_name_type_and_more.py
+++ b/apps/core/migrations/0057_alter_article_name_type_and_more.py
@@ -20,11 +20,4 @@ class Migration(migrations.Migration):
                 verbose_name="익명 혹은 실명 여부",
             ),
         ),
-        migrations.AddIndex(
-            model_name="article",
-            index=models.Index(
-                fields=["created_at", "parent_board_id"],
-                name="created_at_parent_board_id_idx",
-            ),
-        ),
     ]

--- a/apps/core/models/article.py
+++ b/apps/core/models/article.py
@@ -158,13 +158,6 @@ class Article(MetaDataModel):
         verbose_name = "게시물"
         verbose_name_plural = "게시물 목록"
 
-        indexes = [
-            models.Index(
-                fields=["created_at", "parent_board_id"],
-                name="created_at_parent_board_id_idx",
-            )
-        ]
-
     def __str__(self):
         return self.title
 


### PR DESCRIPTION
- Discussion message: https://sparcs.slack.com/archives/CV6H8N4EM/p1704937104870679


- created_at 대신 id로 정렬하는 안 -> 다음 이유로 보류
  - id로 정렬하는 경우, 외부로부터 article을 export 해오는 경우 created_at과 id의 순서가 다를 수 있음 (e.g. 포탈 크롤러)
  - 기타 고려 사항:
      1) 어쨌든 composite index는 생성해야해서 (id, parent_board_id)를 생성하도록 수정했는데, 해당 index 생성이 이전과 마찬가지로 DB에 부하를 줄 가능성이 있음
     2) 프론트엔드에서 GET /articles?ordering=-created_at 으로 최신순 정렬하는 경우를 모두 GET /articles?ordering=-id로 바꿔주어야 함

- Slow Query의 근본적인 원인이 created_at index의 부재가 아니였기 때문에 일단 index를 없애버림