### PR TITLE
fix top k policy

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Run test
         run: |
-          docker-compose -f docker-compose.test.yml run api test
-          docker-compose -f docker-compose.test.yml down
+          docker compose -f docker-compose.test.yml run api test
+          docker compose -f docker-compose.test.yml down
       - if: env.PUSH == 'true'
         name: Push docker image
         run: |

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -480,11 +480,10 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
 
     @decorators.action(detail=False, methods=["get"])
     def top(self, request):
-        # The most recent article at the top
-
         current_date = datetime.datetime.combine(
             timezone.now().date(), datetime.time.min, datetime.timezone.utc
         )
+        # get the articles that are created_at within a week and order by hit_count
         top_articles = Article.objects.filter(
             created_at__gte=current_date - datetime.timedelta(days=7)
         ).order_by("-hit_count", "-pk")

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -1,8 +1,9 @@
-import time
+import datetime
 
 from django.core.paginator import Paginator as DjangoPaginator
 from django.db import models
 from django.http import Http404
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext
 from rest_framework import (
@@ -480,9 +481,13 @@ class ArticleViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
     @decorators.action(detail=False, methods=["get"])
     def top(self, request):
         # The most recent article at the top
-        top_articles = Article.objects.exclude(topped_at__isnull=True).order_by(
-            "-topped_at", "-pk"
+
+        current_date = datetime.datetime.combine(
+            timezone.now().date(), datetime.time.min, datetime.timezone.utc
         )
+        top_articles = Article.objects.filter(
+            created_at__gte=current_date - datetime.timedelta(days=7)
+        ).order_by("-hit_count", "-pk")
 
         search_keyword = request.query_params.get("main_search__contains")
         if search_keyword:

--- a/apps/core/views/viewsets/article.py
+++ b/apps/core/views/viewsets/article.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 from django.core.paginator import Paginator as DjangoPaginator
 from django.db import models

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -720,6 +720,9 @@ class TestArticle(TestCase, RequestSetting):
         The most recently topped article must come first. If the same, then
         the most recent article must come first.
         """
+
+        current_article_count = Article.objects.count()
+
         board = Board.objects.create()
         articles = [
             Article.objects.create(created_by=self.user, parent_board=board)
@@ -731,20 +734,23 @@ class TestArticle(TestCase, RequestSetting):
 
         time_now = timezone.now()
 
-        articles[0].topped_at = time_early
-        articles[1].topped_at = time_early
-        articles[2].topped_at = time_late
-        articles[3].topped_at = time_now
-        articles[4].topped_at = time_now
+        articles[0].created_at = time_early
+        articles[1].created_at = time_early
+        articles[2].created_at = time_late
+        articles[3].created_at = time_now
+        articles[4].created_at = time_now
+
+        articles[3].hit_count = 15
+        articles[4].hit_count = 10
 
         for article in articles:
             article.save()
 
         response = self.http_request(self.user, "get", "articles/top")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["num_items"] == 2
+        assert response.data["num_items"] == current_article_count + 2
 
-        oracle_indices = [5, 4]
+        oracle_indices = [3, 4]
         for idx, res in zip(oracle_indices, response.data["results"]):
             assert articles[idx].pk == res["id"]
 

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -717,8 +717,8 @@ class TestArticle(TestCase, RequestSetting):
 
     def test_top_ordered(self):
         """
-        The most recently topped article must come first. If the same, then
-        the most recent article must come first.
+        Article created in a week has to be in top query result
+        The order is determined by hit_count
         """
 
         current_article_count = Article.objects.count()

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -723,23 +723,28 @@ class TestArticle(TestCase, RequestSetting):
         board = Board.objects.create()
         articles = [
             Article.objects.create(created_by=self.user, parent_board=board)
-            for _ in range(3)
+            for _ in range(5)
         ]
 
         time_early = timezone.datetime(2001, 10, 18)  # retro's birthday
         time_late = timezone.datetime(2003, 6, 17)  # yuwol's birthday
 
+        time_now = timezone.now()
+
         articles[0].topped_at = time_early
         articles[1].topped_at = time_early
         articles[2].topped_at = time_late
+        articles[3].topped_at = time_now
+        articles[4].topped_at = time_now
+
         for article in articles:
             article.save()
 
         response = self.http_request(self.user, "get", "articles/top")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["num_items"] == 3
+        assert response.data["num_items"] == 2
 
-        oracle_indices = [2, 1, 0]
+        oracle_indices = [5, 4]
         for idx, res in zip(oracle_indices, response.data["results"]):
             assert articles[idx].pk == res["id"]
 


### PR DESCRIPTION
기존 인기 개시판은 전체 기간에 대해서 불러오기 때문에 시간이 너무 느립니다.
해당 endpoint 를 최근 1주일내에 만들어진 개시물을 조회수 기준으로 sorting해서 내려줍니다