### PR TITLE
[Hotfix] 학식 크롤링 기능 기한 조정

### DIFF
--- a/apps/core/management/tasks.py
+++ b/apps/core/management/tasks.py
@@ -86,7 +86,8 @@ def crawl_meal():
     current_date = datetime.now()
 
     # 앞 뒤 7일간의 날짜 리스트 생성
-    dates = [(current_date + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(-7, 7)]
+    # 이전 날짜 7일에 경우 학식이 변경된 경우를 아직 처리하지 못 해서 보류. 미래 7일만 가져온다.
+    dates = [(current_date + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(0, 7)]
     for date in dates:
         #식단 크롤링
         crawl_daily_meal(date)


### PR DESCRIPTION
과거 학식을 가져오는 경우 학식 정보가 변경된 경우 대응할 수 있는 방안이 아직 마련되어 있지 않음. (정규식 검사를 통과하지 못 해서 오류가 발생한다.) 따라서 현재 날짜를 기준으로 앞으로 7일간의 학식 정보만 크롤링 해 오는 것으로 바꾸었다.