### PR TITLE
socket api

### DIFF
--- a/apps/chatting/consumers/chat.py
+++ b/apps/chatting/consumers/chat.py
@@ -12,25 +12,55 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
             await self.channel_layer.group_discard(self.room_name, self.channel_name)
             # 필요하면 user_leave 등 이벤트를 방에 알림
 
+    # Helper: room group name
+    def _group(self, room_id: int) -> str:
+        return f"chat_{room_id}"
+
+    # Helper: lightweight user identity for broadcasts
+    def _user_identity(self):
+        user = self.scope.get("user")
+        if user and getattr(user, "is_authenticated", False):
+            return getattr(user, "id", self.channel_name)
+        return self.channel_name
+
     async def receive(self, text_data=None, bytes_data=None):
         data = json.loads(text_data)
         event_type = data.get('type')
 
+        # New protocol
+        if event_type == 'join':
+            await self.join(data['room_id'])
+            return
+        if event_type == 'leave':
+            await self.leave(data['room_id'])
+            return
+        if event_type == 'update':
+            await self.broadcast_update(data.get('payload', {}))
+            return
+
+        # Legacy protocol (backward compatibility)
         if event_type == 'connect_room':
-            await self.connect_room(data['room_id'])
+            await self.join(data['room_id'])
         elif event_type == 'disconnect_room':
-            await self.disconnect_room(data['room_id'])
+            await self.leave(data['room_id'])
         elif event_type == 'typing_start':
             await self.typing_start()
         elif event_type == 'message_new':
-            await self.message_new(data['message'])
+            # normalize to unified room_update payload
+            msg = data.get('message')
+            await self.broadcast_update({
+                'resource': 'messages',
+                'change': 'created',
+                'data': msg,
+                'room_id': msg.get('room_id') if isinstance(msg, dict) else None,
+            })
         # 여기에 더 필요한 이벤트 타입 추가
 
-    async def connect_room(self, room_id):
+    async def join(self, room_id):
         # 기존에 접속한 방 있으면 나가기
         if self.room_name:
             await self.channel_layer.group_discard(self.room_name, self.channel_name)
-        self.room_name = f'chat_{room_id}'
+        self.room_name = self._group(room_id)
         await self.channel_layer.group_add(self.room_name, self.channel_name)
 
         # 방에 접속한 걸 알림 (user_join)
@@ -38,21 +68,28 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
             self.room_name,
             {
                 'type': 'user_join',
-                'user': self.channel_name,  # 실제론 유저 id 등
+                'user': self._user_identity(),  # 실제론 유저 id 등
+                'room_id': room_id,
             }
         )
 
-    async def disconnect_room(self, room_id):
-        room_name = f'chat_{room_id}'
+    async def leave(self, room_id):
+        room_name = self._group(room_id)
         await self.channel_layer.group_discard(room_name, self.channel_name)
 
         await self.channel_layer.group_send(
             room_name,
             {
                 'type': 'user_leave',
-                'user': self.channel_name,
+                'user': self._user_identity(),
+                'room_id': room_id,
             }
         )
+
+    
+        # If leaving current room, clear it
+        if self.room_name == room_name:
+            self.room_name = None
 
     async def typing_start(self):
         # typing_start 이벤트를 그룹에 브로드캐스트
@@ -62,21 +99,30 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
             self.room_name,
             {
                 'type': 'user_typing',
-                'user': self.channel_name,
+                'user': self._user_identity(),
             }
         )
 
-    async def message_new(self, message):
+    async def broadcast_update(self, payload: dict | None = None):
         if not self.room_name:
             return
         await self.channel_layer.group_send(
             self.room_name,
             {
-                'type': 'message_new',
-                'message': message,
-                'user': self.channel_name,
+                'type': 'room_update',
+                'payload': payload or {},
+                'user': self._user_identity(),
             }
         )
+
+    # Deprecated: kept for compatibility; delegate to unified room_update
+    async def broadcast_message_new(self, message):
+        await self.broadcast_update({
+            'resource': 'messages',
+            'change': 'created',
+            'data': message,
+            'room_id': message.get('room_id') if isinstance(message, dict) else None,
+        })
 
     # 그룹에서 이벤트 받는 핸들러들
 
@@ -84,12 +130,14 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
         await self.send(text_data=json.dumps({
             'type': 'user_join',
             'user': event['user'],
+            'room_id': event.get('room_id'),
         }))
 
     async def user_leave(self, event):
         await self.send(text_data=json.dumps({
             'type': 'user_leave',
             'user': event['user'],
+            'room_id': event.get('room_id'),
         }))
 
     async def user_typing(self, event):
@@ -98,9 +146,24 @@ class ChatRoomConsumer(AsyncWebsocketConsumer):
             'user': event['user'],
         }))
 
-    async def message_new(self, event):
+    async def room_update(self, event):
         await self.send(text_data=json.dumps({
-            'type': 'message_new',
-            'message': event['message'],
-            'user': event['user'],
+            'type': 'room_update',
+            'payload': event.get('payload', {}),
+            'user': event.get('user'),
+        }))
+
+    # Backward-compat: if any producer still emits message_new to the group,
+    # convert it to unified room_update for clients
+    async def message_new(self, event):
+        msg = event.get('message')
+        await self.send(text_data=json.dumps({
+            'type': 'room_update',
+            'payload': {
+                'resource': 'messages',
+                'change': 'created',
+                'data': msg,
+                'room_id': msg.get('room_id') if isinstance(msg, dict) else None,
+            },
+            'user': event.get('user'),
         }))

--- a/ara/db/models.py
+++ b/ara/db/models.py
@@ -29,7 +29,7 @@ class MetaDataManager(models.Manager):
     queryset_class = MetaDataQuerySet
 
     def get_queryset(self):
-        tolerance = timedelta(seconds=10)  # timezone 오차 보정 : 10초 여유 -> prevent race condition
+        tolerance = timedelta(seconds=1)  # timezone 오차 보정 : 10초 여유 -> prevent race condition
         adjusted_now = Now() + tolerance #db의 Now를 써야지 timezone.now()를 쓰면 시간이 고정되는 버그 발생
         return self.queryset_class(self.model).filter(
             models.Q(deleted_at=MIN_TIME) | models.Q(deleted_at__gt=adjusted_now)


### PR DESCRIPTION
채팅 기능을 위한 socket api를 정리합니다.

아래는 chat gpt가 써준 socket api 관련 문서입니다...

api/ws/chat

실시간 채팅 WebSocket 프로토콜 문서 (대체 스펙)

개요

- 목적: 채팅방 입장/퇴장, 상태 변경 알림(브로드캐스트), 타이핑 알림.
- 인증: AuthMiddlewareStack 사용. scope.user가 인증되면 [user.id](http://user.id/), 아니면 channel_name으로 식별.

엔드포인트

- ws/chat/ → ChatRoomConsumer
    - 채팅방 관련 모든 실시간 이벤트 처리
- ws/ → WebSocketHandler
    - 별도 용도(이 문서 범위 밖)

공통 규칙

- 룸 그룹명: chat_{room_id}
- 반드시 join 이후에 update/typing 전송
- 알 수 없는 type은 무시
- 서버 브로드캐스트의 user 필드: 기본 [user.id](http://user.id/), 없으면 channel_name

클라이언트 → 서버 이벤트

1. join
- 목적: 방 입장
- 요청 { "type": "join", "room_id": 123 }
1. leave
- 목적: 방 퇴장
- 요청 { "type": "leave", "room_id": 123 }
1. update
- 목적: 방 내 변경(invalidation) 알림 브로드캐스트
- 요청(payload 자유 형식, 권장 스키마 아래 참조) { "type": "update", "payload": { "resource": "messages|room|membership", "room_id": 123, "change": "created|updated|deleted", "data": { ...선택... }, "after_id": 456 // 선택 } }
1. typing_start
- 목적: 타이핑 알림
- 요청 { "type": "typing_start" }

하위호환(레거시)

- connect_room → join과 동일
- disconnect_room → leave와 동일
- message_new → 내부적으로 update로 정규화되어 브로드캐스트됨 { "type": "message_new", "message": { "id": 789, "room_id": 123, "sender_id": 42, "type": "text|image|system", "preview": "내용 미리보기...", "created_at": "2025-08-15T12:34:56Z" } } 서버가 자동 변환해 아래 room_update로 브로드캐스트: { "type": "room_update", "payload": { "resource": "messages", "change": "created", "data": { ...message... }, "room_id": 123 }, "user": 42 }

서버 → 클라이언트 브로드캐스트

- user_join { "type": "user_join", "user": 42, "room_id": 123 }
- user_leave { "type": "user_leave", "user": 42, "room_id": 123 }
- user_typing { "type": "user_typing", "user": 42 }
- room_update { "type": "room_update", "user": 42, "payload": { "resource": "messages|room|membership", "room_id": 123, "change": "created|updated|deleted", "data": { ...선택... }, "after_id": 456 // 선택 } }

payload 권장 스키마(클라→서버 update, 서버→클라 room_update 공통)

- resource: 문자열 enum
    - messages: 메시지 생성/수정/삭제
    - room: 방 메타(제목, 이미지 등) 변경
    - membership: 읽음 포인터/멤버 변경
- room_id: 정수, 대상 방 ID
- change: 문자열 enum created|updated|deleted
- data: 객체, 선택
    - messages 예시: { id, sender_id, type, preview, created_at, ... }
    - room 예시: { title, picture, ... 변경 필드 }
    - membership 예시: { user_id, last_seen_id, ... }
- after_id: 정수, 선택(수신자가 HTTP로 이어받을 커서)

권장 연동 흐름

- 메시지 생성은 HTTP로 수행(POST /api/chat/messages/), 성공 시 서버/클라 어느 쪽이든 update 송신
- 수신자는 room_update를 받으면 HTTP로 동기화
    - GET /api/chat/messages/?chat_room={room_id}&after_id={last_id}&limit={n}
    - GET /api/chat/rooms/{room_id}/
    - POST /api/chat/rooms/{room_id}/read/

예시 시나리오

1. 입장
- send: {"type":"join","room_id":123}
- recv: {"type":"user_join","user":42,"room_id":123}
1. 메시지 추가 알림(정규화)
- send: {"type":"update","payload":{"resource":"messages","room_id":123,"change":"created","data":{"id":789,"preview":"...","sender_id":42}}}
- recv(다른 클라): {"type":"room_update","user":42,"payload":{...}}
- 다른 클라는 이후 HTTP로 최신 메시지 조회

주의사항

- join 없이 update/typing 전송 시 서버는 무시
- 서버 disconnect 시 자동 user_leave 브로드캐스트는 기본 비활성(클라가 leave 전송 권장)
- payload는 가볍게; 상세 데이터는 HTTP로 조회