### PR TITLE
fix(crawlers): meal bulk_create FK + portal soft-fail on unreachable

### DIFF
--- a/apps/core/management/scripts/meal_crawler.py
+++ b/apps/core/management/scripts/meal_crawler.py
@@ -361,10 +361,13 @@ def _save_course_to_db(
             meal_time=meal_time.value,
         )
 
-        menus_to_create = [
-            Menu(menu_name=item[0], course_id=course) for item in menu_list
+        # MySQL 의 bulk_create 는 객체에 PK 를 채워주지 않아서 Django 5 의
+        # unsaved-related-object 체크에 걸린다 (MenuAllergy(menu_id=menu_obj)).
+        # 코스당 메뉴 수가 적으므로 (~10개) 개별 create 로 안전하게 처리한다.
+        created_menus = [
+            Menu.objects.create(menu_name=item[0], course_id=course)
+            for item in menu_list
         ]
-        created_menus = Menu.objects.bulk_create(menus_to_create)
 
         allergies_to_create = []
         for menu_obj, item in zip(created_menus, menu_list):

--- a/apps/kaist/portal/crawler.py
+++ b/apps/kaist/portal/crawler.py
@@ -21,6 +21,14 @@ class DeletedPostException(Exception):
     """
     ...
 
+class PortalUnreachableException(Exception):
+    """
+    Portal 서버에 TCP/TLS 연결이 안 될 때 (ConnectTimeout, ConnectionError 등).
+    session reset 후에도 안 풀리면 발생. 일시적 네트워크/portal-side issue 로 보고
+    celery 다음 cycle 에서 재시도해야 한다.
+    """
+    ...
+
 
 def _build_session() -> requests.Session:
     # connect/read 단계 모두 재시도. celery worker에서 stale keepalive 소켓으로
@@ -113,6 +121,8 @@ class Crawler:
         """
         timeout/retry 가 적용된 GET 요청. ConnectTimeout 등 연결 단계 실패 시
         session 을 재생성해 한 번 더 재시도한다 (stale keepalive 회복용).
+        두 번째 시도도 실패하면 PortalUnreachableException 으로 변환해
+        worker 가 soft-fail 처리할 수 있게 한다.
         """
         try:
             return cls._get_session().get(url, timeout=cls.REQUEST_TIMEOUT)
@@ -121,7 +131,12 @@ class Crawler:
                 f"KAIST Portal Crawler :: connection error on {url} ({e!r}); resetting session"
             )
             cls.reset_session()
-            return cls._get_session().get(url, timeout=cls.REQUEST_TIMEOUT)
+            try:
+                return cls._get_session().get(url, timeout=cls.REQUEST_TIMEOUT)
+            except (requests.ConnectionError, requests.Timeout) as e2:
+                raise PortalUnreachableException(
+                    f"Portal unreachable after session reset: {url} ({e2!r})"
+                ) from e2
 
     @classmethod
     def _parse_response(cls, res: PostResponse) -> Post:

--- a/apps/kaist/portal/worker.py
+++ b/apps/kaist/portal/worker.py
@@ -7,7 +7,12 @@ from datetime import timedelta
 from apps.core.models import Article
 from apps.kaist.models import Post, PostViewCountLog
 from apps.kaist.portal.crawl_iterator import CrawlIterator
-from apps.kaist.portal.crawler import Crawler, DeletedPostException, SessionExpiredException
+from apps.kaist.portal.crawler import (
+    Crawler,
+    DeletedPostException,
+    PortalUnreachableException,
+    SessionExpiredException,
+)
 from apps.user.models import UserProfile
 from ara.log import log
 from library.slack.webhook import slack_webhook_client
@@ -68,6 +73,11 @@ class Worker:
         except SessionExpiredException:
             cls._send_session_expired_alert()
             return
+        except PortalUnreachableException as e:
+            # 일시적 네트워크/portal-side 장애. 다음 celery cycle 에서 재시도되므로
+            # crash 시키지 않고 로그만 남기고 종료한다.
+            log.warning(f"KAIST Portal Crawler :: portal unreachable, will retry next cycle ({e!r})")
+            return
 
         new_posts = posts[1:]
         if not new_posts:
@@ -97,6 +107,9 @@ class Worker:
             return
         except SessionExpiredException:
             cls._send_session_expired_alert()
+            return
+        except PortalUnreachableException as e:
+            log.warning(f"KAIST Portal Crawler :: portal unreachable for post {post_id} ({e!r})")
             return
 
         with transaction.atomic():


### PR DESCRIPTION
Two production regressions surfaced after the Django 5 + crawler refactor:

1. meal: 'bulk_create() prohibited to prevent data loss due to unsaved related object menu_id'. Django 5 enforces that bulk_create'd objects referencing other unsaved objects fail loudly. MySQL bulk_create does NOT populate PKs on the returned objects, so the subsequent MenuAllergy(menu_id=menu_obj) referenced unsaved Menu rows. Switched Menu creation to per-item create() (10 menus/course at most, perf is fine).

2. portal: ConnectTimeout on /wz/api/board/recents/{id} crashed the celery task because _request_get's second attempt (after session reset) was unprotected. Wrapped it, converted persistent unreachability to PortalUnreachableException, and made fetch_and_save_{from_the_latest,single} treat that as a soft failure (log + skip; next celery cycle retries) instead of bubbling up as an unhandled task failure.