### PR TITLE
perf(meal): keep bulk_create + refetch PKs to avoid N+1

### DIFF
--- a/apps/core/management/scripts/meal_crawler.py
+++ b/apps/core/management/scripts/meal_crawler.py
@@ -361,13 +361,13 @@ def _save_course_to_db(
             meal_time=meal_time.value,
         )
 
-        # MySQL 의 bulk_create 는 객체에 PK 를 채워주지 않아서 Django 5 의
-        # unsaved-related-object 체크에 걸린다 (MenuAllergy(menu_id=menu_obj)).
-        # 코스당 메뉴 수가 적으므로 (~10개) 개별 create 로 안전하게 처리한다.
-        created_menus = [
-            Menu.objects.create(menu_name=item[0], course_id=course)
-            for item in menu_list
-        ]
+        # MySQL bulk_create 는 PK 를 안 채워주므로 다시 조회해서 가져온다.
+        Menu.objects.bulk_create(
+            [Menu(menu_name=item[0], course_id=course) for item in menu_list]
+        )
+        created_menus = list(
+            Menu.objects.filter(course_id=course).order_by("id")
+        )
 
         allergies_to_create = []
         for menu_obj, item in zip(created_menus, menu_list):


### PR DESCRIPTION
The previous hotfix switched Menu insertion from bulk_create to per-item create() to dodge Django 5's unsaved-related-object check on the subsequent MenuAllergy(menu_id=menu_obj). That works but does N inserts per course.

Restore bulk_create, then re-query the just-inserted menus by course_id to get instances with PKs filled. Safe because:

- We're inside transaction.atomic(), so no other writer can interleave.
- Course was just created above, so no pre-existing menus on it.
- MySQL auto-increment guarantees id order == insertion order == menu_list order, so the zip with allergens stays correct.

Per course: 4 queries (Course.create, Menu.bulk_create, Menu.filter, MenuAllergy.bulk_create) regardless of menu count, instead of N+2.