### PR TITLE
revert(portal): drop overengineered retry/pool/soft-fail, keep timeou…

### DIFF
--- a/apps/core/management/scripts/meal_crawler.py
+++ b/apps/core/management/scripts/meal_crawler.py
@@ -91,8 +91,8 @@ _COURSE_HEADER_RX = re.compile(
 )
 # 메뉴 + 알러지 (괄호 표기): "김치찌개(1,2,5)"
 _MENU_PAREN_RX = re.compile(r"^(.+?)\(([\d,\s]*)\)\s*$")
-# 메뉴 + 알러지 (점 표기, 서맛골): "김치찌개 1.2.5", "김치찌개 1" 도 허용
-_MENU_DOT_RX = re.compile(r"^(.+?)\s*(\d+(?:\.\d+)*)\s*$")
+# 알러지 표기만 단독으로 있는 라인 (긴 메뉴명 뒤 줄바꿈된 경우): "(1,2,5,6,9,10,13,15)"
+_ALLERGEN_ONLY_RX = re.compile(r"^\(\s*[\d,\s]+\s*\)\s*$")
 
 
 # ---------- 공통 유틸 ----------
@@ -159,19 +159,6 @@ def _parse_menu_paren(text: str) -> MenuItemType:
     return [name, allergens]
 
 
-def _parse_menu_dot(text: str) -> MenuItemType:
-    """'김치찌개 1.2.5' 형식 (서맛골) 의 메뉴 라인을 파싱."""
-    m = _MENU_DOT_RX.match(text)
-    if m:
-        name = m.group(1).strip()
-        try:
-            allergens = [int(x) for x in m.group(2).split(".") if x]
-        except ValueError:
-            return [name, []]
-        return [name, allergens]
-    return [text, []]
-
-
 def _merge_split_price_lines(items: List[str]) -> List[str]:
     """교수회관: 코스명 다음 줄에 가격 '(5,500원)' 이 따로 옴 -> 한 줄로 합침."""
     result: List[str] = []
@@ -179,8 +166,21 @@ def _merge_split_price_lines(items: List[str]) -> List[str]:
         s = raw.strip()
         if not s:
             continue
-        # 직전 라인이 코스 헤더가 아니고, 현재 라인이 가격 표기로만 이루어진 경우 합침
         if "원" in s and result and _parse_course_header(result[-1]) is None:
+            result[-1] = result[-1] + s
+        else:
+            result.append(s)
+    return result
+
+
+def _merge_split_allergen_lines(items: List[str]) -> List[str]:
+    """긴 메뉴명 뒤 알러지 '(1,2,5)' 가 다음 줄로 줄바꿈된 경우 -> 한 줄로 합침."""
+    result: List[str] = []
+    for raw in items:
+        s = raw.strip()
+        if not s:
+            continue
+        if _ALLERGEN_ONLY_RX.match(s) and result and _parse_course_header(result[-1]) is None:
             result[-1] = result[-1] + s
         else:
             result.append(s)
@@ -217,26 +217,29 @@ def _generic_course_parser(
 
 
 def _parser_fclt(menu_list: List[str], time: int) -> CourseDataType:
-    """카이마루: '코스명(5,500원)' / '메뉴(1,2,5)'"""
-    return _generic_course_parser(menu_list, parse_menu=_parse_menu_paren)
+    """카이마루: '코스명(5,500원)' / '메뉴(1,2,5)'. 긴 메뉴명 뒤 알러지가 줄바꿈되는 케이스 처리."""
+    merged = _merge_split_allergen_lines(menu_list)
+    return _generic_course_parser(merged, parse_menu=_parse_menu_paren)
 
 
 def _parser_emp(menu_list: List[str], time: int) -> CourseDataType:
     """교수회관: 카이마루와 동일하나 '코스명' 과 '(5,500원)' 이 다른 라인에 들어옴."""
     merged = _merge_split_price_lines(menu_list)
+    merged = _merge_split_allergen_lines(merged)
     return _generic_course_parser(merged, parse_menu=_parse_menu_paren)
 
 
 def _parser_west(menu_list: List[str], time: int) -> CourseDataType:
     """서맛골: 코스 헤더가 없을 수도 있고, 끼니별로 default 코스명/가격이 정해져 있다.
     - 조식 3,700원 / 중식 5,000원 / 석식 5,000원
-    - 일품(별도 가격) 은 본문에 '[5,000원]' 형태로 등장
-    - 메뉴 알러지 표기는 '김치찌개 1.2.5' 점 구분 형식
+    - 일품(별도 가격) 은 본문에 '[6,500원]' 형태로 등장
+    - 메뉴 알러지는 paren 표기 '시래기들깨국 (5,6)' / '이면(1,5,6)'
     - 조식 마지막 줄에 '천원의 아침밥' 이 붙으면 default 가 (천원의 아침밥, 1000) 로 바뀜
     """
     DEFAULT = {0: ("조식", 3700), 1: ("중식", 5000), 2: ("석식", 5000)}
 
     cleaned = _clean_lines(menu_list)
+    cleaned = _merge_split_allergen_lines(cleaned)
     if not cleaned:
         return {}
     if any(_is_end_marker(l) for l in cleaned[:1]):
@@ -257,7 +260,7 @@ def _parser_west(menu_list: List[str], time: int) -> CourseDataType:
             current = header
             courses.setdefault(current, [])
             continue
-        courses[current].append(_parse_menu_dot(line))
+        courses[current].append(_parse_menu_paren(line))
 
     if not courses[default_course]:
         del courses[default_course]

--- a/apps/kaist/portal/crawler.py
+++ b/apps/kaist/portal/crawler.py
@@ -2,8 +2,6 @@ from datetime import datetime, timezone as dt_timezone
 
 import requests
 from pytz import timezone as pytz_timezone
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from apps.kaist.models import Post
 from apps.kaist.portal.post_response import PostResponse, RecentPostListResponse, RecentPostItem
@@ -21,66 +19,17 @@ class DeletedPostException(Exception):
     """
     ...
 
-class PortalUnreachableException(Exception):
-    """
-    Portal 서버에 TCP/TLS 연결이 안 될 때 (ConnectTimeout, ConnectionError 등).
-    session reset 후에도 안 풀리면 발생. 일시적 네트워크/portal-side issue 로 보고
-    celery 다음 cycle 에서 재시도해야 한다.
-    """
-    ...
-
-
-def _build_session() -> requests.Session:
-    # connect/read 단계 모두 재시도. celery worker에서 stale keepalive 소켓으로
-    # ConnectTimeout 이 누적되는 것을 막기 위해 backoff retry 와 풀 사이즈를 명시한다.
-    retry = Retry(
-        total=3,
-        connect=3,
-        read=2,
-        backoff_factor=1.0,
-        status_forcelist=(500, 502, 503, 504),
-        allowed_methods=("GET",),
-        raise_on_status=False,
-    )
-    adapter = HTTPAdapter(
-        max_retries=retry,
-        pool_connections=20,
-        pool_maxsize=20,
-    )
-    session = requests.Session()
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    session.cookies.set(Crawler.SESSION_KEY, PORTAL_JSESSIONID)
-    return session
-
 
 class Crawler:
     SESSION_KEY = "JSESSIONID"
     SESSION_REDIS_KEY = "crawler:jsessionid"
 
-    # (connect_timeout, read_timeout) - 무제한 block 방지
-    REQUEST_TIMEOUT = (5, 30)
+    REQUEST_TIMEOUT = (5, 30)  # (connect, read) — 무한 block 방지
 
-    _session = None  # lazy init via _get_session()
+    _session = requests.Session()
+    _session.cookies.set(SESSION_KEY, PORTAL_JSESSIONID)
 
     _KST = pytz_timezone("Asia/Seoul")
-
-    @classmethod
-    def _get_session(cls) -> requests.Session:
-        if cls._session is None:
-            cls._session = _build_session()
-        return cls._session
-
-    @classmethod
-    def reset_session(cls) -> None:
-        """stale connection pool 을 폐기하고 새로운 session 으로 교체."""
-        old = cls._session
-        cls._session = _build_session()
-        if old is not None:
-            try:
-                old.close()
-            except Exception:
-                pass
 
     @classmethod
     def _parse_datetime_string(cls, datetime_str: str) -> datetime:
@@ -89,7 +38,7 @@ class Crawler:
             .astimezone(cls._KST)
             .astimezone(dt_timezone.utc)
         )
-    
+
     @classmethod
     def _is_deleted_post(cls, html_txt: str) -> bool:
         if not html_txt:
@@ -97,13 +46,14 @@ class Crawler:
         # 삭제 판단의 기준이 되는 text
         mask_txt = ["서비스 이용에 불편을 드려 죄송합니다.", ]
         return any(txt in html_txt for txt in mask_txt)
-    
+
     #post 사이의 링크가 끊긴 경우를 위해 현재를 기준으로 가장 최근 post id를 가져옵니다.
     @classmethod
     def _get_recent_post_id(cls) -> int:
         try:
-            response = cls._request_get(
-                "https://portal.kaist.ac.kr/wz/api/board/recents/"
+            response = cls._session.get(
+                "https://portal.kaist.ac.kr/wz/api/board/recents/",
+                timeout=cls.REQUEST_TIMEOUT,
             )
             payload = response.json()  # 제공된 응답은 유효 JSON
             items = payload["data"]
@@ -115,28 +65,6 @@ class Crawler:
         #응답이 html인 경우 (권한 없음 페이지) session expired
         except Exception:
             raise SessionExpiredException
-
-    @classmethod
-    def _request_get(cls, url: str) -> requests.Response:
-        """
-        timeout/retry 가 적용된 GET 요청. ConnectTimeout 등 연결 단계 실패 시
-        session 을 재생성해 한 번 더 재시도한다 (stale keepalive 회복용).
-        두 번째 시도도 실패하면 PortalUnreachableException 으로 변환해
-        worker 가 soft-fail 처리할 수 있게 한다.
-        """
-        try:
-            return cls._get_session().get(url, timeout=cls.REQUEST_TIMEOUT)
-        except (requests.ConnectionError, requests.Timeout) as e:
-            log.warning(
-                f"KAIST Portal Crawler :: connection error on {url} ({e!r}); resetting session"
-            )
-            cls.reset_session()
-            try:
-                return cls._get_session().get(url, timeout=cls.REQUEST_TIMEOUT)
-            except (requests.ConnectionError, requests.Timeout) as e2:
-                raise PortalUnreachableException(
-                    f"Portal unreachable after session reset: {url} ({e2!r})"
-                ) from e2
 
     @classmethod
     def _parse_response(cls, res: PostResponse) -> Post:
@@ -184,14 +112,15 @@ class Crawler:
         retry_count = 1
 
         while retry_count >= 0:
-            response = cls._request_get(
-                f"https://portal.kaist.ac.kr/wz/api/board/recents/{post_id}"
+            response = cls._session.get(
+                f"https://portal.kaist.ac.kr/wz/api/board/recents/{post_id}",
+                timeout=cls.REQUEST_TIMEOUT,
             )
 
             if cls._has_fetched_successfully(response):
                 post = cls._parse_response(response.json())
                 return post
-            
+
             if cls._is_deleted_post(response.text):
                 raise DeletedPostException(f"Post {post_id} has been deleted")
 
@@ -204,13 +133,14 @@ class Crawler:
     @classmethod
     def get_view_count(cls, post_id : int) -> int | None:
 
-        response = cls._request_get(
-            f"https://portal.kaist.ac.kr/wz/api/board/recents/{post_id}"
+        response = cls._session.get(
+            f"https://portal.kaist.ac.kr/wz/api/board/recents/{post_id}",
+            timeout=cls.REQUEST_TIMEOUT,
         )
         if cls._has_fetched_successfully(response):
             post = cls._parse_response(response.json())
             return post.view_count
-            
+
         else:
             return None
 
@@ -241,4 +171,4 @@ class Crawler:
             log.info(
                 f"KAIST Portal Crawler :: JSESSIONID updated to ({new_session_id})"
             )
-            cls._get_session().cookies.set(cls.SESSION_KEY, new_session_id)
+            cls._session.cookies.set(cls.SESSION_KEY, new_session_id)

--- a/apps/kaist/portal/worker.py
+++ b/apps/kaist/portal/worker.py
@@ -10,7 +10,6 @@ from apps.kaist.portal.crawl_iterator import CrawlIterator
 from apps.kaist.portal.crawler import (
     Crawler,
     DeletedPostException,
-    PortalUnreachableException,
     SessionExpiredException,
 )
 from apps.user.models import UserProfile
@@ -73,11 +72,6 @@ class Worker:
         except SessionExpiredException:
             cls._send_session_expired_alert()
             return
-        except PortalUnreachableException as e:
-            # 일시적 네트워크/portal-side 장애. 다음 celery cycle 에서 재시도되므로
-            # crash 시키지 않고 로그만 남기고 종료한다.
-            log.warning(f"KAIST Portal Crawler :: portal unreachable, will retry next cycle ({e!r})")
-            return
 
         new_posts = posts[1:]
         if not new_posts:
@@ -107,9 +101,6 @@ class Worker:
             return
         except SessionExpiredException:
             cls._send_session_expired_alert()
-            return
-        except PortalUnreachableException as e:
-            log.warning(f"KAIST Portal Crawler :: portal unreachable for post {post_id} ({e!r})")
             return
 
         with transaction.atomic():


### PR DESCRIPTION
…t only

ConnectTimeout 의 root cause 는 portal 측 IP 차단으로 보이며 client-side retry/pool/reset_session 으로는 해결되지 않는다. soft-fail 처리는 outage 를 숨겨 진단을 늦추기까지 했다. timeout 추가 + _has_fetched_successfully 의 defensive .get() + _get_recent_post_id URL trailing slash 만 남기고 나머지는 이전 단순 버전으로 되돌린다. 실패 시 task 가 crash 하면서 Sentry 가 다시 가시성을 확보한다.