### PR TITLE
chore(portal): deprecate view-count sync to ease portal load

### DIFF
--- a/apps/core/management/tasks.py
+++ b/apps/core/management/tasks.py
@@ -63,6 +63,7 @@ def _get_best(days, period):
 
     return BestArticle.objects.bulk_create(articles)
 
+# Deprecated: beat schedule 제거됨. portal 부담 때문에 비활성화 (재설계 전까지 사용 금지).
 @celery_app.task
 def sync_portal_view_counts():
     PortalCrawlWorker.sync_portal_view_count()

--- a/apps/kaist/portal/worker.py
+++ b/apps/kaist/portal/worker.py
@@ -203,6 +203,7 @@ class Worker:
             ]
         )
 
+    # Deprecated: 매 tick 마다 3일치 post 전체에 대해 portal GET 을 날리는 부담 때문에 스케줄에서 제거됨.
     @staticmethod
     def sync_portal_view_count() -> None:
 

--- a/ara/celery.py
+++ b/ara/celery.py
@@ -28,11 +28,7 @@ app.conf.beat_schedule = {
         "schedule": settings.SCHEDULERS["CRAWL_PORTAL"]["CRONTAB"],
         "args": [],
     },
-    "sync_portal_view_counts": {
-        "task": "apps.core.management.tasks.sync_portal_view_counts",
-        "schedule": settings.SCHEDULERS["SYNC_PORTAL_VIEW_COUNTS"]["CRONTAB"],
-        "args": [],
-    },
+    # sync_portal_view_counts: deprecated — 매 10분 portal 다발 호출 부담으로 비활성화
     "save_daily_best": {
         "task": "apps.core.management.tasks.save_daily_best",
         "schedule": settings.SCHEDULERS["SAVE_DAILY_BEST"]["CRONTAB"],

--- a/ara/settings/scheduler.py
+++ b/ara/settings/scheduler.py
@@ -33,9 +33,6 @@ SCHEDULERS = {
     "CRAWL_PORTAL": create_scheduler_config(
         "CRAWL_PORTAL", crontab=crontab(minute="*/10"),
     ),  # 매 0분 (1시간마다)
-    "SYNC_PORTAL_VIEW_COUNTS": create_scheduler_config(
-        "SYNC_PORTAL_VIEW_COUNTS", crontab=crontab(minute="*/10"), #dev 용으로 10분, 기능 개발 이후 1시간으로 변경
-    ),
     "SAVE_DAILY_BEST": create_scheduler_config(
         "SAVE_DAILY_BEST", crontab=crontab(minute=0)
     ),


### PR DESCRIPTION
매 10분마다 최근 3일치 모든 Post 에 대해 portal 에 GET 을 날리던
sync_portal_view_count task 를 beat schedule 에서 제거. task 함수와 Worker 메서드, PostViewCountLog 모델은 보존 (기존 로그 데이터와 trending 잔여 의존성 유지).